### PR TITLE
fix: correct NestJS build output path in Dockerfile

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -32,4 +32,4 @@ RUN echo "Build completed, checking dist folder:" && ls -la dist/ || echo "No di
 EXPOSE 3000
 
 # Start the application (we're already in the right directory)
-CMD ["node", "dist/src/main.js"]
+CMD ["node", "dist/main.js"]

--- a/apps/api/src/db/connection.ts
+++ b/apps/api/src/db/connection.ts
@@ -17,7 +17,10 @@ export function getDatabase() {
         max: 20,
         idleTimeoutMillis: 30000,
         connectionTimeoutMillis: 2000,
-        ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
+        ssl:
+          process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test'
+            ? { rejectUnauthorized: false }
+            : false,
       });
     }
 


### PR DESCRIPTION
- Changed CMD from dist/src/main.js to dist/main.js
- NestJS outputs directly to dist/ folder, not dist/src/
- Also enabled SSL for test environment database connections