### PR TITLE
address onboarding issues

### DIFF
--- a/apps/api/src/auth/auth.config.ts
+++ b/apps/api/src/auth/auth.config.ts
@@ -340,7 +340,7 @@ If you didn't request this, you can ignore this email.
           // Return user data with userType from invitation
           console.log('Returning user data for signup with name:', name);
           return {
-            email,
+            email: emailLower,
             name: name || '', // Use the name from signup form
             userType: invitation.userType,
             emailVerified: false,

--- a/apps/api/src/invitations/invitations.service.ts
+++ b/apps/api/src/invitations/invitations.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { desc, eq } from 'drizzle-orm';
+import { desc, eq, sql } from 'drizzle-orm';
 import { generateInvitationToken } from '../auth/auth.config';
 import { getDatabase } from '../db/connection';
 import { invitations, users } from '../db/schema';
@@ -33,8 +33,12 @@ export class InvitationsService {
     console.log('  - User type:', dto.userType);
     console.log('==========================================');
 
-    // Check if user already exists
-    const existingUser = await db.select().from(users).where(eq(users.email, emailLower)).limit(1);
+    // Check if user already exists (case-insensitive; signup may preserve typed casing)
+    const existingUser = await db
+      .select()
+      .from(users)
+      .where(sql`lower(trim(${users.email})) = ${emailLower}`)
+      .limit(1);
 
     if (existingUser[0]) {
       throw new ConflictException('A user with this email already exists');

--- a/apps/api/src/scholars/scholars.service.ts
+++ b/apps/api/src/scholars/scholars.service.ts
@@ -38,22 +38,25 @@ export class ScholarsService {
     createScholarDto: CreateScholarDto,
     createdBy: string
   ): Promise<{ success: boolean; message: string; scholar?: any }> {
-    // Check if a user with this email already exists
+    // Match invitation + auth flows (always lowercase in `invitations`; users may differ by case from signup)
+    const emailNormalized = createScholarDto.email.trim().toLowerCase();
+
+    // Check if a user with this email already exists (case-insensitive)
     const existingUser = await database
       .select()
       .from(users)
-      .where(eq(users.email, createScholarDto.email))
+      .where(sql`lower(trim(${users.email})) = ${emailNormalized}`)
       .limit(1);
 
     if (existingUser.length > 0) {
       throw new ConflictException('A user with this email already exists');
     }
 
-    // Check if there's an existing pending invitation
+    // Check if there's an existing pending invitation (emails are stored lowercase)
     const existingInvitation = await database
       .select()
       .from(invitations)
-      .where(and(eq(invitations.email, createScholarDto.email), eq(invitations.status, 'pending')))
+      .where(and(eq(invitations.email, emailNormalized), eq(invitations.status, 'pending')))
       .limit(1);
 
     if (existingInvitation.length > 0) {
@@ -62,7 +65,7 @@ export class ScholarsService {
 
     // Create the invitation with scholar data
     const invitationData = {
-      email: createScholarDto.email,
+      email: emailNormalized,
       userType: 'scholar' as const,
       scholarData: {
         name: createScholarDto.name,
@@ -96,7 +99,7 @@ export class ScholarsService {
 
     return {
       success: true,
-      message: `Scholar invitation sent to ${createScholarDto.email}`,
+      message: `Scholar invitation sent to ${emailNormalized}`,
       scholar: invitation,
     };
   }

--- a/apps/staff/components/scholar-management-table.tsx
+++ b/apps/staff/components/scholar-management-table.tsx
@@ -3,6 +3,8 @@
 import {
   AlertCircle,
   Archive,
+  ChevronLeft,
+  ChevronRight,
   Download,
   Eye,
   Loader2,
@@ -13,10 +15,11 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import {
-  type GetScholarsParams,
   downloadAllScholarsCSV,
+  type GetScholarsParams,
   getFilterOptions,
   getScholars,
+  type PaginationMeta,
   type Scholar,
   type ScholarFilterOptions,
 } from '../lib/api-client';
@@ -53,7 +56,7 @@ export function ScholarManagementTable({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
-  const [_totalPages, setTotalPages] = useState(1);
+  const [pagination, setPagination] = useState<PaginationMeta | null>(null);
 
   const [programFilter, setProgramFilter] = useState('all');
   const [yearFilter, setYearFilter] = useState('all');
@@ -84,6 +87,12 @@ export function ScholarManagementTable({
     return () => clearTimeout(timer);
   }, [searchTerm]);
 
+  const scholarListFilterKey = `${programFilter}|${yearFilter}|${universityFilter}|${statusFilter}`;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset pagination when program/year/university/status filters change
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [scholarListFilterKey]);
+
   const fetchScholars = useCallback(async () => {
     setIsLoading(true);
     setError(null);
@@ -103,7 +112,7 @@ export function ScholarManagementTable({
 
       const response = await getScholars(params);
       setScholars(response.data);
-      setTotalPages(response.pagination.totalPages);
+      setPagination(response.pagination);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load scholars');
       console.error('Error fetching scholars:', err);
@@ -514,6 +523,52 @@ export function ScholarManagementTable({
           </TableBody>
         </Table>
       </div>
+
+      {pagination && pagination.totalItems > 0 && (
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm text-gray-600">
+          <p>
+            Showing{' '}
+            <span className="font-medium text-gray-900">
+              {(pagination.page - 1) * pagination.limit + 1}
+            </span>
+            –
+            <span className="font-medium text-gray-900">
+              {Math.min(pagination.page * pagination.limit, pagination.totalItems)}
+            </span>{' '}
+            of <span className="font-medium text-gray-900">{pagination.totalItems}</span> scholars
+            {pagination.totalPages > 1 && (
+              <>
+                {' '}
+                (page {pagination.page} of {pagination.totalPages})
+              </>
+            )}
+          </p>
+          {pagination.totalPages > 1 && (
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!pagination.hasPrev}
+                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              >
+                <ChevronLeft className="h-4 w-4 mr-1" />
+                Previous
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!pagination.hasNext}
+                onClick={() => setCurrentPage((p) => p + 1)}
+              >
+                Next
+                <ChevronRight className="h-4 w-4 ml-1" />
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
1. Scholars who could not be onboarded (invitation / “already exists” errors)
Cause: Invitations are stored with a lowercased email, but createScholar was checking users and invitations with the exact string from the form. PostgreSQL string equality is case-sensitive, so you could get wrong outcomes, for example:

A user already registered as Foday.Dampha@warwick.ac.uk (from signup) while staff tries foday.dampha@warwick.ac.uk → duplicate user not detected in the first step, then confusing conflicts or inconsistent behaviour.
Pending invites stored as lowercase not matching the typed address the same way as invitations do.
Changes:

37:105:apps/api/src/scholars/scholars.service.ts – Normalize with trim().toLowerCase(), use that for the invitation payload, use case-insensitive existence check on users (lower(trim(email))), and match pending invitations on the normalized address.
36:41:apps/api/src/invitations/invitations.service.ts – Same case-insensitive check when deciding if a user already exists before creating an invitation.
340:347:apps/api/src/auth/auth.config.ts – Scholar sign-up now persists emailLower on the user row so it stays aligned with invitations.
After deploy, retry onboarding for those four addresses (same addresses are fine; casing no longer matters). If staff still see “A user with this email already exists”, that scholar already has an account and you should not send a new invite—use support / account linking instead. If they see “An invitation has already been sent”, cancel the old invite in the invitations UI (or DB) and send again, or use resend if it is still valid.

2. Lurvish Polodoo: active but not on the list unless searching
Cause: The API returns 20 scholars per page ordered by createdAt descending, but the staff table never rendered pagination—it only ever showed the first page. Search shrinks the result set, so he appeared there.

Changes: 515:568:apps/staff/components/scholar-management-table.tsx – Footer with “Showing X–Y of Z”, page indicator when there is more than one page, and Previous / Next. Changing program/year/university/status resets to page 1 so you do not land on an empty page.

