### PR TITLE
ASH-10 ASH-11 Add announcement filters and sorting

### DIFF
--- a/apps/api/src/announcements/announcements.controller.ts
+++ b/apps/api/src/announcements/announcements.controller.ts
@@ -1,9 +1,21 @@
-import { Body, Controller, Delete, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+  ValidationPipe,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import type { Request } from 'express';
 import { AuthGuard } from '../auth/auth.guard';
 import { AnnouncementsService } from './announcements.service';
 import { CreateAnnouncementDto, ScholarFilterDto } from './dto/create-announcement.dto';
+import { GetAnnouncementsQueryDto } from './dto/get-announcements.dto';
 
 interface AuthenticatedRequest extends Request {
   user?: {
@@ -20,8 +32,11 @@ export class AnnouncementsController {
   constructor(private readonly announcementsService: AnnouncementsService) {}
 
   @Get()
-  async getAnnouncements() {
-    return this.announcementsService.getAnnouncements();
+  async getAnnouncements(
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: GetAnnouncementsQueryDto
+  ) {
+    return this.announcementsService.getAnnouncements(query);
   }
 
   @Post()
@@ -47,12 +62,16 @@ export class AnnouncementsController {
   }
 
   @Get('my-announcements')
-  async getMyAnnouncements(@Req() req: AuthenticatedRequest) {
+  async getMyAnnouncements(
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: GetAnnouncementsQueryDto,
+    @Req() req: AuthenticatedRequest
+  ) {
     const userId = req.user?.id;
     if (!userId) {
       throw new Error('User not authenticated');
     }
-    return this.announcementsService.getAnnouncementsForScholar(userId);
+    return this.announcementsService.getAnnouncementsForScholar(userId, query);
   }
 
   @Delete(':id')

--- a/apps/api/src/announcements/announcements.service.ts
+++ b/apps/api/src/announcements/announcements.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { and, count, desc, eq, inArray } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray } from 'drizzle-orm';
 import { database } from '../db/connection';
 import {
   announcementFilters,
@@ -10,6 +10,12 @@ import {
 } from '../db/schema';
 import { EmailService } from '../email/email.service';
 import { CreateAnnouncementDto, ScholarFilterDto } from './dto/create-announcement.dto';
+import { GetAnnouncementsQueryDto } from './dto/get-announcements.dto';
+
+type AnnouncementFilter = {
+  type: string;
+  value: string;
+};
 
 @Injectable()
 export class AnnouncementsService {
@@ -47,7 +53,18 @@ export class AnnouncementsService {
     return announcement;
   }
 
-  async getAnnouncements() {
+  async getAnnouncements(query: GetAnnouncementsQueryDto = {}) {
+    const status = query.status ?? 'active';
+    const whereConditions = [];
+
+    if (status === 'active') {
+      whereConditions.push(eq(announcements.archived, false));
+    }
+
+    if (status === 'archived') {
+      whereConditions.push(eq(announcements.archived, true));
+    }
+
     const result = await database
       .select({
         announcement: announcements,
@@ -55,8 +72,10 @@ export class AnnouncementsService {
       })
       .from(announcements)
       .innerJoin(users, eq(announcements.createdBy, users.id))
-      .where(eq(announcements.archived, false))
-      .orderBy(desc(announcements.createdAt));
+      .where(whereConditions.length > 0 ? and(...whereConditions) : undefined)
+      .orderBy(
+        query.sortOrder === 'asc' ? asc(announcements.createdAt) : desc(announcements.createdAt)
+      );
 
     const announcementsWithDetails = await Promise.all(
       result.map(async (row) => {
@@ -79,16 +98,20 @@ export class AnnouncementsService {
           createdBy: row.creator.name,
           createdAt: row.announcement.createdAt,
           updatedAt: row.announcement.updatedAt,
+          archived: row.announcement.archived,
+          archivedAt: row.announcement.archivedAt,
           filters: filters.map((f) => ({ type: f.filterType, value: f.filterValue })),
           recipientCount: recipientCount[0]?.count || 0,
         };
       })
     );
 
-    return announcementsWithDetails;
+    return announcementsWithDetails.filter((announcement) =>
+      this.matchesAnnouncementFilters(announcement.filters, query)
+    );
   }
 
-  async getAnnouncementsForScholar(userId: string) {
+  async getAnnouncementsForScholar(userId: string, query: GetAnnouncementsQueryDto = {}) {
     // First, get the scholar ID from the user ID
     const scholar = await database
       .select()
@@ -117,19 +140,33 @@ export class AnnouncementsService {
       .where(
         and(eq(announcementRecipients.scholarId, scholarId), eq(announcements.archived, false))
       )
-      .orderBy(desc(announcements.createdAt));
+      .orderBy(
+        query.sortOrder === 'asc' ? asc(announcements.createdAt) : desc(announcements.createdAt)
+      );
 
     // Format the announcements
-    const announcementsForScholar = result.map((row) => ({
-      id: row.announcement.id,
-      title: row.announcement.title,
-      content: row.announcement.content,
-      createdBy: row.creator.name,
-      createdAt: row.announcement.createdAt,
-      updatedAt: row.announcement.updatedAt,
-    }));
+    const announcementsForScholar = await Promise.all(
+      result.map(async (row) => {
+        const filters = await database
+          .select()
+          .from(announcementFilters)
+          .where(eq(announcementFilters.announcementId, row.announcement.id));
 
-    return announcementsForScholar;
+        return {
+          id: row.announcement.id,
+          title: row.announcement.title,
+          content: row.announcement.content,
+          createdBy: row.creator.name,
+          createdAt: row.announcement.createdAt,
+          updatedAt: row.announcement.updatedAt,
+          filters: filters.map((f) => ({ type: f.filterType, value: f.filterValue })),
+        };
+      })
+    );
+
+    return announcementsForScholar.filter((announcement) =>
+      this.matchesAnnouncementFilters(announcement.filters, query)
+    );
   }
 
   async getScholarsForFiltering(): Promise<ScholarFilterDto[]> {
@@ -309,5 +346,24 @@ export class AnnouncementsService {
 
     // Wait for all emails to be sent
     await Promise.allSettled(emailPromises);
+  }
+
+  private matchesAnnouncementFilters(
+    filters: AnnouncementFilter[],
+    query: Pick<GetAnnouncementsQueryDto, 'year' | 'program' | 'university'>
+  ): boolean {
+    const activeFilters = [
+      ['year', query.year],
+      ['program', query.program],
+      ['university', query.university],
+    ].filter((filter): filter is [string, string] => Boolean(filter[1]));
+
+    if (activeFilters.length === 0) {
+      return true;
+    }
+
+    return activeFilters.every(([type, value]) =>
+      filters.some((filter) => filter.type === type && filter.value === value)
+    );
   }
 }

--- a/apps/api/src/announcements/dto/get-announcements.dto.ts
+++ b/apps/api/src/announcements/dto/get-announcements.dto.ts
@@ -1,0 +1,25 @@
+import { Transform } from 'class-transformer';
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+export class GetAnnouncementsQueryDto {
+  @IsOptional()
+  @IsString()
+  year?: string;
+
+  @IsOptional()
+  @IsString()
+  program?: string;
+
+  @IsOptional()
+  @IsString()
+  university?: string;
+
+  @IsOptional()
+  @IsEnum(['active', 'archived', 'all'])
+  status?: 'active' | 'archived' | 'all' = 'active';
+
+  @IsOptional()
+  @IsEnum(['asc', 'desc'])
+  @Transform(({ value }) => value?.toLowerCase())
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}

--- a/apps/api/src/scholars/dto/update-scholar-profile.dto.ts
+++ b/apps/api/src/scholars/dto/update-scholar-profile.dto.ts
@@ -13,6 +13,10 @@ export class UpdateScholarProfileDto {
   // - email (from users table)
   // - aaiScholarId
 
+  @IsOptional()
+  @IsString()
+  image?: string | null;
+
   // Personal Information
   @IsOptional()
   @IsString() // Changed from @IsDateString() to allow empty strings

--- a/apps/api/src/scholars/scholars.service.ts
+++ b/apps/api/src/scholars/scholars.service.ts
@@ -1,4 +1,9 @@
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { and, count, desc, eq, ilike, inArray, not, or, sql } from 'drizzle-orm';
 import { database } from '../db/connection';
 import {
@@ -33,6 +38,19 @@ import { UpdateScholarProfileDto } from './dto/update-scholar-profile.dto';
 @Injectable()
 export class ScholarsService {
   constructor(private readonly invitationsService: InvitationsService) {}
+
+  private validateProfileImage(image: string | null | undefined) {
+    if (!image) return;
+
+    const isSupportedDataUrl = /^data:image\/(jpeg|png|webp|gif);base64,/i.test(image);
+    if (!isSupportedDataUrl) {
+      throw new BadRequestException('Profile image must be a JPEG, PNG, WebP, or GIF data URL');
+    }
+
+    if (image.length > 3_000_000) {
+      throw new BadRequestException('Profile image must be smaller than 2MB');
+    }
+  }
 
   async createScholar(
     createScholarDto: CreateScholarDto,
@@ -781,6 +799,7 @@ export class ScholarsService {
       bio,
       majorCategory,
       fieldOfStudy,
+      image,
     } = profileUpdateData;
 
     // Update scholar record - handle empty strings and date conversions properly
@@ -832,6 +851,14 @@ export class ScholarsService {
     if (fieldOfStudy !== undefined) dbUpdateData.fieldOfStudy = fieldOfStudy || null;
 
     await database.update(scholars).set(dbUpdateData).where(eq(scholars.id, scholarId));
+
+    if (image !== undefined) {
+      this.validateProfileImage(image);
+      await database
+        .update(users)
+        .set({ image: image || null, updatedAt: new Date() })
+        .where(eq(users.id, userId));
+    }
 
     // Return updated profile
     return this.getScholarProfileByUserId(userId);

--- a/apps/api/src/users/dto/update-user.dto.ts
+++ b/apps/api/src/users/dto/update-user.dto.ts
@@ -6,4 +6,9 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   name?: string;
+
+  @ApiProperty({ required: false, description: 'User profile image as a data URL' })
+  @IsOptional()
+  @IsString()
+  image?: string | null;
 }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { database } from '../db/connection';
 import { staff, users } from '../db/schema';
@@ -6,6 +6,19 @@ import { UpdateUserDto } from './dto/update-user.dto';
 
 @Injectable()
 export class UsersService {
+  private validateProfileImage(image: string | null | undefined) {
+    if (!image) return;
+
+    const isSupportedDataUrl = /^data:image\/(jpeg|png|webp|gif);base64,/i.test(image);
+    if (!isSupportedDataUrl) {
+      throw new BadRequestException('Profile image must be a JPEG, PNG, WebP, or GIF data URL');
+    }
+
+    if (image.length > 3_000_000) {
+      throw new BadRequestException('Profile image must be smaller than 2MB');
+    }
+  }
+
   async findById(userId: string) {
     const user = await database.select().from(users).where(eq(users.id, userId)).limit(1);
 
@@ -18,14 +31,21 @@ export class UsersService {
   }
 
   async updateUser(userId: string, updateUserDto: UpdateUserDto) {
-    // Only update name in users table if provided
-    if (updateUserDto.name) {
+    const updateData: Partial<typeof users.$inferInsert> = { updatedAt: new Date() };
+
+    if (updateUserDto.name !== undefined) {
+      updateData.name = updateUserDto.name;
+    }
+
+    if (updateUserDto.image !== undefined) {
+      this.validateProfileImage(updateUserDto.image);
+      updateData.image = updateUserDto.image || null;
+    }
+
+    if (Object.keys(updateData).length > 1) {
       const updatedUser = await database
         .update(users)
-        .set({
-          name: updateUserDto.name,
-          updatedAt: new Date(),
-        })
+        .set(updateData)
         .where(eq(users.id, userId))
         .returning();
 
@@ -36,7 +56,7 @@ export class UsersService {
       return updatedUser[0];
     }
 
-    // If no name provided, just return the existing user
+    // If no supported fields were provided, just return the existing user
     return this.findById(userId);
   }
 

--- a/apps/scholar/app/(scholar)/announcements/page.tsx
+++ b/apps/scholar/app/(scholar)/announcements/page.tsx
@@ -1,15 +1,126 @@
 'use client';
 
 import { AlertCircle, Bell } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Button } from '../../../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../../components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../../components/ui/select';
 import { useMyAnnouncements } from '../../../lib/hooks/use-queries';
 
 export default function AnnouncementsPage() {
-  const { data: announcements, isLoading, error } = useMyAnnouncements();
+  const [yearFilter, setYearFilter] = useState('all');
+  const [programFilter, setProgramFilter] = useState('all');
+  const [universityFilter, setUniversityFilter] = useState('all');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const { data: announcements, isLoading, error } = useMyAnnouncements({ sortOrder });
+  const filterOptions = useMemo(() => {
+    const options = {
+      years: new Set<string>(),
+      programs: new Set<string>(),
+      universities: new Set<string>(),
+    };
+
+    announcements?.forEach((announcement) => {
+      announcement.filters?.forEach((filter) => {
+        if (filter.type === 'year') options.years.add(filter.value);
+        if (filter.type === 'program') options.programs.add(filter.value);
+        if (filter.type === 'university') options.universities.add(filter.value);
+      });
+    });
+
+    return {
+      years: Array.from(options.years).sort(),
+      programs: Array.from(options.programs).sort(),
+      universities: Array.from(options.universities).sort(),
+    };
+  }, [announcements]);
+  const filteredAnnouncements = useMemo(() => {
+    const selectedFilters = [
+      ['year', yearFilter],
+      ['program', programFilter],
+      ['university', universityFilter],
+    ].filter((filter) => filter[1] !== 'all');
+
+    if (!announcements || selectedFilters.length === 0) {
+      return announcements || [];
+    }
+
+    return announcements.filter((announcement) =>
+      selectedFilters.every(([type, value]) =>
+        announcement.filters?.some((filter) => filter.type === type && filter.value === value)
+      )
+    );
+  }, [announcements, yearFilter, programFilter, universityFilter]);
+
+  const clearFilters = () => {
+    setYearFilter('all');
+    setProgramFilter('all');
+    setUniversityFilter('all');
+    setSortOrder('desc');
+  };
 
   return (
     <div className="p-6 space-y-4">
       <h2 className="text-2xl font-bold text-foreground">Announcements</h2>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        <Select value={yearFilter} onValueChange={setYearFilter}>
+          <SelectTrigger>
+            <SelectValue placeholder="Year" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Years</SelectItem>
+            {filterOptions.years.map((year) => (
+              <SelectItem key={year} value={year}>
+                {year}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={programFilter} onValueChange={setProgramFilter}>
+          <SelectTrigger>
+            <SelectValue placeholder="Program" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Programs</SelectItem>
+            {filterOptions.programs.map((program) => (
+              <SelectItem key={program} value={program}>
+                {program}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={universityFilter} onValueChange={setUniversityFilter}>
+          <SelectTrigger>
+            <SelectValue placeholder="University" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Universities</SelectItem>
+            {filterOptions.universities.map((university) => (
+              <SelectItem key={university} value={university}>
+                {university}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={sortOrder} onValueChange={(value) => setSortOrder(value as 'asc' | 'desc')}>
+          <SelectTrigger>
+            <SelectValue placeholder="Sort" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="desc">Most Recent</SelectItem>
+            <SelectItem value="asc">Oldest First</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button variant="outline" onClick={clearFilters}>
+          Reset
+        </Button>
+      </div>
 
       {isLoading ? (
         <Card className="border-ashinaga-teal-100 dark:border-border">
@@ -35,21 +146,21 @@ export default function AnnouncementsPage() {
             </div>
           </CardContent>
         </Card>
-      ) : !announcements || announcements.length === 0 ? (
+      ) : filteredAnnouncements.length === 0 ? (
         <Card className="border-ashinaga-teal-100 dark:border-border">
           <CardContent className="pt-6">
             <div className="text-center py-8">
               <Bell className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-              <p className="text-muted-foreground">No announcements yet</p>
+              <p className="text-muted-foreground">No announcements found</p>
               <p className="text-sm text-muted-foreground mt-2">
-                Check back later for updates from staff
+                Try changing your filters or check back later for updates from staff
               </p>
             </div>
           </CardContent>
         </Card>
       ) : (
         <div className="space-y-4">
-          {announcements.map((announcement) => (
+          {filteredAnnouncements.map((announcement) => (
             <Card key={announcement.id} className="border-ashinaga-teal-100 dark:border-border">
               <CardHeader>
                 <div className="flex items-start justify-between">

--- a/apps/scholar/components/my-profile.tsx
+++ b/apps/scholar/components/my-profile.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import {
+  AlertTriangle,
   Calendar,
+  Camera,
+  Edit,
   FileText,
   Globe,
   GraduationCap,
@@ -9,25 +12,27 @@ import {
   Lock,
   Phone,
   Save,
+  Trash2,
   User,
-  AlertTriangle,
-  Edit,
   X,
 } from 'lucide-react';
+import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import {
   getMyProfile,
-  updateMyProfile,
   type ScholarProfile,
   type UpdateProfileData,
+  updateMyProfile,
 } from '../lib/api/profile';
+import { Alert, AlertDescription } from './ui/alert';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { Button } from './ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from './ui/dialog';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Textarea } from './ui/textarea';
-import { Alert, AlertDescription } from './ui/alert';
 
 export function MyProfile() {
   const [profile, setProfile] = useState<ScholarProfile | null>(null);
@@ -35,6 +40,7 @@ export function MyProfile() {
   const [saving, setSaving] = useState(false);
   const [editing, setEditing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [formData, setFormData] = useState<UpdateProfileData>({});
 
@@ -44,6 +50,7 @@ export function MyProfile() {
       setProfile(data);
       // Initialize form data with current profile values
       setFormData({
+        image: data.image || null,
         phone: data.phone || '',
         dateOfBirth: data.dateOfBirth || '',
         gender: data.gender || undefined,
@@ -84,6 +91,7 @@ export function MyProfile() {
     e.preventDefault();
     setSaving(true);
     setError(null);
+    setImageError(null);
     setSuccess(false);
 
     try {
@@ -105,6 +113,7 @@ export function MyProfile() {
     // Reset form data to current profile values
     if (profile) {
       setFormData({
+        image: profile.image || null,
         phone: profile.phone || '',
         dateOfBirth: profile.dateOfBirth || '',
         gender: profile.gender || undefined,
@@ -132,6 +141,31 @@ export function MyProfile() {
     }
   };
 
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    setImageError(null);
+
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      setImageError('Please choose an image file.');
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      setImageError('Please choose an image smaller than 2MB.');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      setFormData((current) => ({ ...current, image: reader.result as string }));
+    };
+    reader.onerror = () => setImageError('Could not read that image. Please try another file.');
+    reader.readAsDataURL(file);
+  };
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -153,6 +187,8 @@ export function MyProfile() {
       </Alert>
     );
   }
+
+  const profileImage = formData.image || profile.image;
 
   return (
     <div className="space-y-6">
@@ -202,6 +238,84 @@ export function MyProfile() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
+            <div className="flex items-center gap-6">
+              {profileImage ? (
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <button
+                      type="button"
+                      className="rounded-full focus:outline-none focus:ring-2 focus:ring-ashinaga-teal-600 focus:ring-offset-2"
+                      aria-label="Open profile picture"
+                    >
+                      <Avatar className="h-20 w-20 cursor-pointer">
+                        <AvatarImage src={profileImage} alt={profile.name} />
+                        <AvatarFallback className="text-lg bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 text-white">
+                          {profile.name
+                            ?.split(' ')
+                            .map((n) => n[0])
+                            .join('')
+                            .toUpperCase() || 'U'}
+                        </AvatarFallback>
+                      </Avatar>
+                    </button>
+                  </DialogTrigger>
+                  <DialogContent className="max-w-xl p-4">
+                    <DialogTitle className="sr-only">Profile picture</DialogTitle>
+                    <Image
+                      src={profileImage}
+                      alt={profile.name || 'Profile picture'}
+                      width={800}
+                      height={800}
+                      unoptimized
+                      className="max-h-[75vh] w-full rounded-md object-contain"
+                    />
+                  </DialogContent>
+                </Dialog>
+              ) : (
+                <Avatar className="h-20 w-20">
+                  <AvatarFallback className="text-lg bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 text-white">
+                    {profile.name
+                      ?.split(' ')
+                      .map((n) => n[0])
+                      .join('')
+                      .toUpperCase() || 'U'}
+                  </AvatarFallback>
+                </Avatar>
+              )}
+              <div>
+                <p className="font-medium text-foreground">{profile.name}</p>
+                <p className="text-sm text-muted-foreground">{profile.email}</p>
+                {editing && (
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <Button asChild variant="outline" size="sm">
+                      <label htmlFor="profile-picture">
+                        <Camera className="h-4 w-4" />
+                        Upload Photo
+                      </label>
+                    </Button>
+                    {(formData.image || profile.image) && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setFormData((current) => ({ ...current, image: null }))}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        Remove
+                      </Button>
+                    )}
+                    <Input
+                      id="profile-picture"
+                      type="file"
+                      accept="image/*"
+                      className="sr-only"
+                      onChange={handleImageChange}
+                    />
+                  </div>
+                )}
+                {imageError && <p className="mt-2 text-sm text-red-600">{imageError}</p>}
+              </div>
+            </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="name">Name</Label>
@@ -248,7 +362,9 @@ export function MyProfile() {
                 <Label htmlFor="gender">Gender</Label>
                 <Select
                   value={formData.gender}
-                  onValueChange={(value: any) => setFormData({ ...formData, gender: value })}
+                  onValueChange={(value) =>
+                    setFormData({ ...formData, gender: value as UpdateProfileData['gender'] })
+                  }
                   disabled={!editing}
                 >
                   <SelectTrigger>

--- a/apps/scholar/lib/api-client.ts
+++ b/apps/scholar/lib/api-client.ts
@@ -43,10 +43,33 @@ export interface Announcement {
   createdBy: string;
   createdAt: string;
   updatedAt: string;
+  filters?: Array<{ type: string; value: string }>;
 }
 
-export async function getMyAnnouncements(): Promise<Announcement[]> {
-  return fetchAPI<Announcement[]>('/api/announcements/my-announcements');
+export interface GetMyAnnouncementsParams {
+  year?: string;
+  program?: string;
+  university?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export async function getMyAnnouncements(
+  params?: GetMyAnnouncementsParams
+): Promise<Announcement[]> {
+  const queryParams = new URLSearchParams();
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null && value !== '' && value !== 'all') {
+        queryParams.append(key, String(value));
+      }
+    });
+  }
+
+  const queryString = queryParams.toString();
+  return fetchAPI<Announcement[]>(
+    `/api/announcements/my-announcements${queryString ? `?${queryString}` : ''}`
+  );
 }
 
 // Request types and functions

--- a/apps/scholar/lib/api/profile.ts
+++ b/apps/scholar/lib/api/profile.ts
@@ -42,6 +42,7 @@ export interface ScholarProfile {
 }
 
 export interface UpdateProfileData {
+  image?: string | null;
   phone?: string;
   dateOfBirth?: string;
   gender?: 'male' | 'female' | 'other' | 'prefer_not_to_say';

--- a/apps/scholar/lib/hooks/use-queries.ts
+++ b/apps/scholar/lib/hooks/use-queries.ts
@@ -1,18 +1,24 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { createRequest, getMyAnnouncements, getMyRequests, getStaffList } from '../api-client';
+import {
+  createRequest,
+  type GetMyAnnouncementsParams,
+  getMyAnnouncements,
+  getMyRequests,
+  getStaffList,
+} from '../api-client';
 
 // Query keys
 export const queryKeys = {
-  myAnnouncements: ['my-announcements'] as const,
+  myAnnouncements: (params?: GetMyAnnouncementsParams) => ['my-announcements', params] as const,
   myRequests: ['my-requests'] as const,
   staffList: ['staff-list'] as const,
 };
 
 // My announcements query
-export function useMyAnnouncements(enabled = true) {
+export function useMyAnnouncements(params?: GetMyAnnouncementsParams, enabled = true) {
   return useQuery({
-    queryKey: queryKeys.myAnnouncements,
-    queryFn: getMyAnnouncements,
+    queryKey: queryKeys.myAnnouncements(params),
+    queryFn: () => getMyAnnouncements(params),
     enabled,
   });
 }

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -500,7 +500,7 @@ function StaffDashboardContent() {
                           <SelectItem value="pending">Pending</SelectItem>
                           <SelectItem value="approved">Approved</SelectItem>
                           <SelectItem value="rejected">Rejected</SelectItem>
-                          <SelectItem value="reviewed">Reviewed</SelectItem>
+                          <SelectItem value="reviewed">On Hold</SelectItem>
                         </SelectContent>
                       </Select>
                     </div>

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { AlertCircle, FileText, Loader2, MessageSquare, Plus, Trash2, Users } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { AnnouncementCreator } from '../components/announcement-creator';
 import { LoginPage } from '../components/login-page';
 import { MyProfile } from '../components/my-profile';
@@ -25,7 +25,9 @@ import {
 } from '../components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../components/ui/tabs';
 import {
+  type AnnouncementFilterOptions,
   deleteAnnouncement,
+  getAnnouncementFilterOptions,
   getRequestStats,
   getRequests,
   getScholarStats,
@@ -64,6 +66,21 @@ function StaffDashboardContent() {
   >((scholarTabFromUrl as 'profile' | 'goals' | 'tasks' | 'documents') || 'profile');
   const [requestCategoryFilter, setRequestCategoryFilter] = useState('all');
   const [requestStatusFilter, setRequestStatusFilter] = useState('all');
+  const [announcementYearFilter, setAnnouncementYearFilter] = useState('all');
+  const [announcementProgramFilter, setAnnouncementProgramFilter] = useState('all');
+  const [announcementUniversityFilter, setAnnouncementUniversityFilter] = useState('all');
+  const [announcementStatusFilter, setAnnouncementStatusFilter] = useState<
+    'active' | 'archived' | 'all'
+  >('active');
+  const [announcementSortOrder, setAnnouncementSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [announcementFilterOptions, setAnnouncementFilterOptions] =
+    useState<AnnouncementFilterOptions>({
+      programs: [],
+      years: [],
+      universities: [],
+      locations: [],
+      statuses: [],
+    });
   const [requests, setRequests] = useState<Request[]>([]);
   const [requestsLoading, setRequestsLoading] = useState(true);
   const [requestsError, setRequestsError] = useState<string | null>(null);
@@ -77,6 +94,22 @@ function StaffDashboardContent() {
   const isLoading = session.isPending;
   const isAuthenticated = !!user;
   const isStaff = user?.userType === 'staff';
+  const announcementParams = useMemo(
+    () => ({
+      year: announcementYearFilter !== 'all' ? announcementYearFilter : undefined,
+      program: announcementProgramFilter !== 'all' ? announcementProgramFilter : undefined,
+      university: announcementUniversityFilter !== 'all' ? announcementUniversityFilter : undefined,
+      status: announcementStatusFilter,
+      sortOrder: announcementSortOrder,
+    }),
+    [
+      announcementYearFilter,
+      announcementProgramFilter,
+      announcementUniversityFilter,
+      announcementStatusFilter,
+      announcementSortOrder,
+    ]
+  );
 
   // Handle non-staff users
   useEffect(() => {
@@ -93,7 +126,7 @@ function StaffDashboardContent() {
     isLoading: announcementsLoading,
     error: announcementsError,
     refetch: refetchAnnouncements,
-  } = useAnnouncements(isAuthenticated);
+  } = useAnnouncements(announcementParams, isAuthenticated);
 
   // Update state when URL changes
   useEffect(() => {
@@ -207,6 +240,15 @@ function StaffDashboardContent() {
     }
   }, []);
 
+  const fetchAnnouncementFilterOptions = useCallback(async () => {
+    try {
+      const options = await getAnnouncementFilterOptions();
+      setAnnouncementFilterOptions(options);
+    } catch (err) {
+      console.error('Error fetching announcement filter options:', err);
+    }
+  }, []);
+
   // Announcements are now fetched via React Query
 
   useEffect(() => {
@@ -215,9 +257,24 @@ function StaffDashboardContent() {
       fetchRequests();
       fetchScholarStats();
       fetchRequestStats();
+      fetchAnnouncementFilterOptions();
       // Announcements are now auto-fetched by React Query
     }
-  }, [isAuthenticated, fetchRequests, fetchScholarStats, fetchRequestStats]);
+  }, [
+    isAuthenticated,
+    fetchRequests,
+    fetchScholarStats,
+    fetchRequestStats,
+    fetchAnnouncementFilterOptions,
+  ]);
+
+  const clearAnnouncementFilters = () => {
+    setAnnouncementYearFilter('all');
+    setAnnouncementProgramFilter('all');
+    setAnnouncementUniversityFilter('all');
+    setAnnouncementStatusFilter('active');
+    setAnnouncementSortOrder('desc');
+  };
 
   const handleRequestStatusUpdate = (requestId: string, status: string, comment?: string) => {
     console.log('Request updated:', { requestId, status, comment });
@@ -559,6 +616,88 @@ function StaffDashboardContent() {
                   </div>
                 </CardHeader>
                 <CardContent>
+                  <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-5">
+                      <Select
+                        value={announcementStatusFilter}
+                        onValueChange={(value) =>
+                          setAnnouncementStatusFilter(value as 'active' | 'archived' | 'all')
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="active">Active</SelectItem>
+                          <SelectItem value="archived">Archived</SelectItem>
+                          <SelectItem value="all">All Statuses</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={announcementYearFilter}
+                        onValueChange={setAnnouncementYearFilter}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Year" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All Years</SelectItem>
+                          {announcementFilterOptions.years.map((year) => (
+                            <SelectItem key={year} value={year}>
+                              {year}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={announcementProgramFilter}
+                        onValueChange={setAnnouncementProgramFilter}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Program" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All Programs</SelectItem>
+                          {announcementFilterOptions.programs.map((program) => (
+                            <SelectItem key={program} value={program}>
+                              {program}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={announcementUniversityFilter}
+                        onValueChange={setAnnouncementUniversityFilter}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="University" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All Universities</SelectItem>
+                          {announcementFilterOptions.universities.map((university) => (
+                            <SelectItem key={university} value={university}>
+                              {university}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Select
+                        value={announcementSortOrder}
+                        onValueChange={(value) => setAnnouncementSortOrder(value as 'asc' | 'desc')}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Sort" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="desc">Most Recent</SelectItem>
+                          <SelectItem value="asc">Oldest First</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <Button variant="outline" onClick={clearAnnouncementFilters}>
+                      Reset
+                    </Button>
+                  </div>
                   {announcementsLoading ? (
                     <div className="flex items-center justify-center py-12">
                       <Loader2 className="h-6 w-6 animate-spin" />
@@ -574,7 +713,7 @@ function StaffDashboardContent() {
                   ) : announcements.length === 0 ? (
                     <div className="text-center py-12 text-gray-500">
                       <MessageSquare className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                      <p>No announcements yet. Create your first announcement to get started.</p>
+                      <p>No announcements match the current filters.</p>
                     </div>
                   ) : (
                     <div className="space-y-4">
@@ -598,6 +737,8 @@ function StaffDashboardContent() {
                                     Sent to {announcement.recipientCount} scholar
                                     {announcement.recipientCount !== 1 ? 's' : ''}
                                   </span>
+                                  <span className="mx-2">•</span>
+                                  <span>{announcement.archived ? 'Archived' : 'Active'}</span>
                                 </div>
                                 {announcement.filters.length > 0 && (
                                   <div className="flex gap-1">

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -12,7 +12,7 @@ import { ScholarOnboarding } from '../components/scholar-onboarding';
 import { ScholarProfilePage } from '../components/scholar-profile';
 import { StaffInviteDialog } from '../components/staff-invite-dialog';
 import { TaskAssignment } from '../components/task-assignment';
-import { Avatar, AvatarFallback } from '../components/ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from '../components/ui/avatar';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
@@ -280,15 +280,23 @@ function StaffDashboardContent() {
             <Button variant="outline" size="sm" onClick={handleSignOut}>
               Logout
             </Button>
-            <Avatar>
-              <AvatarFallback>
-                {user?.name
-                  ?.split(' ')
-                  .map((n: string) => n[0])
-                  .join('')
-                  .toUpperCase() || 'U'}
-              </AvatarFallback>
-            </Avatar>
+            <button
+              type="button"
+              className="rounded-full focus:outline-none focus:ring-2 focus:ring-ashinaga-teal-600 focus:ring-offset-2"
+              onClick={() => router.push('?view=my-profile')}
+              aria-label="Open my profile"
+            >
+              <Avatar className="cursor-pointer">
+                {user?.image && <AvatarImage src={user.image} alt={user.name || 'User'} />}
+                <AvatarFallback>
+                  {user?.name
+                    ?.split(' ')
+                    .map((n: string) => n[0])
+                    .join('')
+                    .toUpperCase() || 'U'}
+                </AvatarFallback>
+              </Avatar>
+            </button>
           </div>
         </div>
       </header>

--- a/apps/staff/components/my-profile.tsx
+++ b/apps/staff/components/my-profile.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { ArrowLeft, Save } from 'lucide-react';
+import { ArrowLeft, Camera, Save, Trash2 } from 'lucide-react';
+import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import { useSession } from '../lib/auth-client';
 import { useUpdateUser } from '../lib/hooks/use-queries';
-import { Avatar, AvatarFallback } from './ui/avatar';
+import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
 import { Button } from './ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from './ui/dialog';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { useToast } from './ui/use-toast';
@@ -24,8 +26,11 @@ export function MyProfile({ onBack }: MyProfileProps) {
   const [profileData, setProfileData] = useState({
     name: '',
     email: '',
+    image: null as string | null,
   });
   const [isEditing, setIsEditing] = useState(false);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const profileImage = profileData.image;
 
   // Initialize form with user data
   useEffect(() => {
@@ -33,6 +38,7 @@ export function MyProfile({ onBack }: MyProfileProps) {
       setProfileData({
         name: user.name || '',
         email: user.email || '',
+        image: user.image || null,
       });
     }
   }, [user]);
@@ -47,15 +53,43 @@ export function MyProfile({ onBack }: MyProfileProps) {
       setProfileData({
         name: user.name || '',
         email: user.email || '',
+        image: user.image || null,
       });
     }
+    setImageError(null);
     setIsEditing(false);
+  };
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    setImageError(null);
+
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      setImageError('Please choose an image file.');
+      return;
+    }
+
+    if (file.size > 2 * 1024 * 1024) {
+      setImageError('Please choose an image smaller than 2MB.');
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      setProfileData((prev) => ({ ...prev, image: reader.result as string }));
+    };
+    reader.onerror = () => setImageError('Could not read that image. Please try another file.');
+    reader.readAsDataURL(file);
   };
 
   const handleSave = async () => {
     updateUserMutation.mutate(
       {
         name: profileData.name,
+        image: profileData.image,
       },
       {
         onSuccess: () => {
@@ -94,18 +128,81 @@ export function MyProfile({ onBack }: MyProfileProps) {
         <CardContent className="space-y-6">
           {/* Avatar Section */}
           <div className="flex items-center gap-6">
-            <Avatar className="h-20 w-20">
-              <AvatarFallback className="text-lg bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 text-white">
-                {profileData.name
-                  ?.split(' ')
-                  .map((n) => n[0])
-                  .join('')
-                  .toUpperCase() || 'U'}
-              </AvatarFallback>
-            </Avatar>
+            {profileImage ? (
+              <Dialog>
+                <DialogTrigger asChild>
+                  <button
+                    type="button"
+                    className="rounded-full focus:outline-none focus:ring-2 focus:ring-ashinaga-teal-600 focus:ring-offset-2"
+                    aria-label="Open profile picture"
+                  >
+                    <Avatar className="h-20 w-20 cursor-pointer">
+                      <AvatarImage src={profileImage} alt={profileData.name} />
+                      <AvatarFallback className="text-lg bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 text-white">
+                        {profileData.name
+                          ?.split(' ')
+                          .map((n) => n[0])
+                          .join('')
+                          .toUpperCase() || 'U'}
+                      </AvatarFallback>
+                    </Avatar>
+                  </button>
+                </DialogTrigger>
+                <DialogContent className="max-w-xl p-4">
+                  <DialogTitle className="sr-only">Profile picture</DialogTitle>
+                  <Image
+                    src={profileImage}
+                    alt={profileData.name || 'Profile picture'}
+                    width={800}
+                    height={800}
+                    unoptimized
+                    className="max-h-[75vh] w-full rounded-md object-contain"
+                  />
+                </DialogContent>
+              </Dialog>
+            ) : (
+              <Avatar className="h-20 w-20">
+                <AvatarFallback className="text-lg bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 text-white">
+                  {profileData.name
+                    ?.split(' ')
+                    .map((n) => n[0])
+                    .join('')
+                    .toUpperCase() || 'U'}
+                </AvatarFallback>
+              </Avatar>
+            )}
             <div>
               <h3 className="text-lg font-medium">{profileData.name}</h3>
               <p className="text-sm text-gray-600">{profileData.email}</p>
+              {isEditing && (
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <Button asChild variant="outline" size="sm">
+                    <label htmlFor="profile-picture">
+                      <Camera className="h-4 w-4" />
+                      Upload Photo
+                    </label>
+                  </Button>
+                  {profileData.image && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setProfileData((prev) => ({ ...prev, image: null }))}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Remove
+                    </Button>
+                  )}
+                  <Input
+                    id="profile-picture"
+                    type="file"
+                    accept="image/*"
+                    className="sr-only"
+                    onChange={handleImageChange}
+                  />
+                </div>
+              )}
+              {imageError && <p className="mt-2 text-sm text-red-600">{imageError}</p>}
             </div>
           </div>
 

--- a/apps/staff/components/request-management.tsx
+++ b/apps/staff/components/request-management.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CheckCircle, Download, Eye, Paperclip, Trash2, X } from 'lucide-react';
+import { CheckCircle, Clock, Download, Eye, Paperclip, Trash2, X } from 'lucide-react';
 import { useState } from 'react';
 import {
   deleteRequest,
@@ -9,6 +9,7 @@ import {
   updateRequestStatus,
 } from '../lib/api-client';
 import { useSession } from '../lib/auth-client';
+import { getFormDataDisplayItems, REQUEST_TYPE_LABELS } from '../lib/form-data-labels';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { Card, CardContent } from './ui/card';
@@ -30,6 +31,8 @@ interface RequestManagementProps {
   onStatusUpdate: (requestId: string, status: string, comment?: string) => void;
 }
 
+type ReviewStatus = 'approved' | 'rejected' | 'reviewed';
+
 export function RequestManagement({ request, onStatusUpdate }: RequestManagementProps) {
   const [approvalOpen, setApprovalOpen] = useState(false);
   const [viewReviewOpen, setViewReviewOpen] = useState(false);
@@ -46,7 +49,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
   // Debug logging
   console.log('Auth state:', { user, isLoading, isAuthenticated });
 
-  const handleApproval = async (approved: boolean) => {
+  const handleStatusUpdate = async (status: ReviewStatus) => {
     if (!user?.id) {
       console.error('User not authenticated. Auth state:', { user, isLoading, isAuthenticated });
       alert('Please log in to perform this action.');
@@ -55,7 +58,6 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
 
     setIsSubmitting(true);
     try {
-      const status = approved ? 'approved' : 'rejected';
       await updateRequestStatus(request.id, status, approvalComment, user.id);
       onStatusUpdate(request.id, status, approvalComment);
       setApprovalOpen(false);
@@ -66,6 +68,10 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleApproval = async (approved: boolean) => {
+    await handleStatusUpdate(approved ? 'approved' : 'rejected');
   };
 
   const handleDownload = async (attachmentId: string, filename: string) => {
@@ -152,6 +158,72 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
     }
   };
 
+  const getStatusLabel = (status: string) => {
+    if (status === 'reviewed') return 'on hold';
+    return status;
+  };
+
+  const applicationItems = getFormDataDisplayItems(request.type, request.formData);
+  const requestTypeLabel = REQUEST_TYPE_LABELS[request.type] || request.type.replace(/_/g, ' ');
+
+  const renderCompletedApplication = () => (
+    <div className="bg-gray-50 p-4 rounded-lg">
+      <h4 className="font-medium mb-3">Completed Application</h4>
+      <div className="space-y-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Request Type</p>
+          <p className="text-sm text-gray-700">{requestTypeLabel}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Description</p>
+          <p className="text-sm text-gray-700 whitespace-pre-wrap">{request.description}</p>
+        </div>
+        {applicationItems.length > 0 && (
+          <div className="border-t border-gray-200 pt-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">
+              Application Responses
+            </p>
+            <div className="space-y-3">
+              {applicationItems.map((item, index) => (
+                <div key={`${item.label}-${index}`}>
+                  <p className="text-sm font-medium text-gray-800">{item.label}</p>
+                  <p className="text-sm text-gray-700 whitespace-pre-wrap">{item.value}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {request.attachments && request.attachments.length > 0 && (
+          <div className="border-t border-gray-200 pt-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">
+              Attachments ({request.attachments.length})
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {request.attachments.map((attachment) => (
+                <div
+                  key={attachment.id}
+                  className="flex items-center gap-2 bg-white rounded px-2 py-1"
+                >
+                  <span className="text-xs text-gray-700">{attachment.name}</span>
+                  <span className="text-xs text-gray-500">({attachment.size})</span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-4 w-4 p-0"
+                    disabled={isDownloading === attachment.id}
+                    onClick={() => handleDownload(attachment.id, attachment.name)}
+                  >
+                    <Download className="h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <Card className="p-4 border border-ashinaga-teal-100 rounded-lg">
       <CardContent className="p-0">
@@ -160,7 +232,9 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
             <div className="flex items-center gap-2 mb-2">
               <h4 className="font-medium text-gray-900">{request.scholarName}</h4>
               <Badge variant={getPriorityColor(request.priority)}>{request.priority}</Badge>
-              <Badge className={getStatusBadgeColor(request.status)}>{request.status}</Badge>
+              <Badge className={getStatusBadgeColor(request.status)}>
+                {getStatusLabel(request.status)}
+              </Badge>
             </div>
             <p className="text-sm text-gray-600 mb-2">{request.description}</p>
 
@@ -197,19 +271,22 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
             )}
 
             <div className="flex items-center gap-4 text-sm text-gray-500">
-              <span>Type: {request.type.replace('_', ' ')}</span>
+              <span>Type: {requestTypeLabel}</span>
               <span>Submitted: {new Date(request.submittedDate).toLocaleDateString()}</span>
             </div>
 
             {/* Show review details if already reviewed */}
             {(request.status === 'approved' ||
               request.status === 'rejected' ||
+              request.status === 'reviewed' ||
               request.status === 'commented') &&
               request.reviewComment && (
                 <div className="mt-3 p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center gap-2 mb-2">
                     <span className="text-sm font-medium text-gray-700">Review:</span>
-                    <Badge className={getStatusBadgeColor(request.status)}>{request.status}</Badge>
+                    <Badge className={getStatusBadgeColor(request.status)}>
+                      {getStatusLabel(request.status)}
+                    </Badge>
                   </div>
                   <p className="text-sm text-gray-600">{request.reviewComment}</p>
                   {request.reviewDate && (
@@ -233,50 +310,15 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                       Review
                     </Button>
                   </DialogTrigger>
-                  <DialogContent>
+                  <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
                     <DialogHeader>
                       <DialogTitle>Review Request</DialogTitle>
                       <DialogDescription>
-                        Approve or reject the request from {request.scholarName}
+                        Review the completed application from {request.scholarName}
                       </DialogDescription>
                     </DialogHeader>
                     <div className="space-y-4">
-                      <div className="bg-gray-50 p-4 rounded-lg">
-                        <h4 className="font-medium mb-2">Request Details</h4>
-                        <p className="text-sm text-gray-600 mb-2">
-                          <strong>Type:</strong> {request.type.replace('_', ' ')}
-                        </p>
-                        <p className="text-sm text-gray-600 mb-2">
-                          <strong>Description:</strong> {request.description}
-                        </p>
-                        {request.attachments && request.attachments.length > 0 && (
-                          <div className="mt-2">
-                            <p className="text-sm text-gray-600 mb-2">
-                              <strong>Attachments:</strong> {request.attachments.length} file(s)
-                            </p>
-                            <div className="flex flex-wrap gap-2">
-                              {request.attachments.map((attachment) => (
-                                <div
-                                  key={attachment.name}
-                                  className="flex items-center gap-2 bg-white rounded px-2 py-1"
-                                >
-                                  <span className="text-xs text-gray-700">{attachment.name}</span>
-                                  <span className="text-xs text-gray-500">({attachment.size})</span>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    className="h-4 w-4 p-0"
-                                    disabled={isDownloading === attachment.id}
-                                    onClick={() => handleDownload(attachment.id, attachment.name)}
-                                  >
-                                    <Download className="h-3 w-3" />
-                                  </Button>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
+                      {renderCompletedApplication()}
                       <div>
                         <Label htmlFor="approvalComment">Comments (Optional)</Label>
                         <Textarea
@@ -300,6 +342,15 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                       >
                         <X className="h-4 w-4 mr-2" />
                         {isSubmitting ? 'Processing...' : 'Reject'}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => handleStatusUpdate('reviewed')}
+                        disabled={isSubmitting}
+                        className="text-purple-700 border-purple-200 hover:bg-purple-50"
+                      >
+                        <Clock className="h-4 w-4 mr-2" />
+                        {isSubmitting ? 'Processing...' : 'Put On Hold'}
                       </Button>
                       <Button
                         onClick={() => handleApproval(true)}
@@ -326,6 +377,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
             {/* View Review Button for already reviewed requests */}
             {(request.status === 'approved' ||
               request.status === 'rejected' ||
+              request.status === 'reviewed' ||
               request.status === 'commented') && (
               <Dialog open={viewReviewOpen} onOpenChange={setViewReviewOpen}>
                 <DialogTrigger asChild>
@@ -334,7 +386,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                     View Review
                   </Button>
                 </DialogTrigger>
-                <DialogContent>
+                <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
                   <DialogHeader>
                     <DialogTitle>Review Details</DialogTitle>
                     <DialogDescription>
@@ -342,46 +394,12 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                     </DialogDescription>
                   </DialogHeader>
                   <div className="space-y-4">
-                    <div className="bg-gray-50 p-4 rounded-lg">
-                      <h4 className="font-medium mb-2">Request Details</h4>
-                      <p className="text-sm text-gray-600 mb-2">
-                        <strong>Type:</strong> {request.type.replace('_', ' ')}
-                      </p>
-                      <p className="text-sm text-gray-600 mb-2">
-                        <strong>Description:</strong> {request.description}
-                      </p>
-                      {request.attachments && request.attachments.length > 0 && (
-                        <div className="mt-2">
-                          <p className="text-sm text-gray-600 mb-2">
-                            <strong>Attachments:</strong> {request.attachments.length} file(s)
-                          </p>
-                          <div className="flex flex-wrap gap-2">
-                            {request.attachments.map((attachment) => (
-                              <div
-                                key={attachment.name}
-                                className="flex items-center gap-2 bg-white rounded px-2 py-1"
-                              >
-                                <span className="text-xs text-gray-700">{attachment.name}</span>
-                                <span className="text-xs text-gray-500">({attachment.size})</span>
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  className="h-4 w-4 p-0"
-                                  onClick={() => handleDownload(attachment.url, attachment.name)}
-                                >
-                                  <Download className="h-3 w-3" />
-                                </Button>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </div>
+                    {renderCompletedApplication()}
                     <div>
                       <Label>Review Decision</Label>
                       <div className="mt-2">
                         <Badge className={getStatusBadgeColor(request.status)}>
-                          {request.status}
+                          {getStatusLabel(request.status)}
                         </Badge>
                       </div>
                     </div>

--- a/apps/staff/components/request-management.tsx
+++ b/apps/staff/components/request-management.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CheckCircle, Download, Eye, Paperclip, Trash2, X } from 'lucide-react';
+import { CheckCircle, Clock, Download, Eye, Paperclip, Trash2, X } from 'lucide-react';
 import { useState } from 'react';
 import {
   deleteRequest,
@@ -9,6 +9,7 @@ import {
   updateRequestStatus,
 } from '../lib/api-client';
 import { useSession } from '../lib/auth-client';
+import { getFormDataDisplayItems, REQUEST_TYPE_LABELS } from '../lib/form-data-labels';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { Card, CardContent } from './ui/card';
@@ -30,6 +31,8 @@ interface RequestManagementProps {
   onStatusUpdate: (requestId: string, status: string, comment?: string) => void;
 }
 
+type ReviewStatus = 'approved' | 'rejected' | 'reviewed';
+
 export function RequestManagement({ request, onStatusUpdate }: RequestManagementProps) {
   const [approvalOpen, setApprovalOpen] = useState(false);
   const [viewReviewOpen, setViewReviewOpen] = useState(false);
@@ -46,7 +49,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
   // Debug logging
   console.log('Auth state:', { user, isLoading, isAuthenticated });
 
-  const handleApproval = async (approved: boolean) => {
+  const handleStatusUpdate = async (status: ReviewStatus) => {
     if (!user?.id) {
       console.error('User not authenticated. Auth state:', { user, isLoading, isAuthenticated });
       alert('Please log in to perform this action.');
@@ -55,7 +58,6 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
 
     setIsSubmitting(true);
     try {
-      const status = approved ? 'approved' : 'rejected';
       await updateRequestStatus(request.id, status, approvalComment, user.id);
       onStatusUpdate(request.id, status, approvalComment);
       setApprovalOpen(false);
@@ -66,6 +68,10 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleApproval = async (approved: boolean) => {
+    await handleStatusUpdate(approved ? 'approved' : 'rejected');
   };
 
   const handleDownload = async (attachmentId: string, filename: string) => {
@@ -152,6 +158,72 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
     }
   };
 
+  const getStatusLabel = (status: string) => {
+    if (status === 'reviewed') return 'reviewed';
+    return status;
+  };
+
+  const applicationItems = getFormDataDisplayItems(request.type, request.formData);
+  const requestTypeLabel = REQUEST_TYPE_LABELS[request.type] || request.type.replace(/_/g, ' ');
+
+  const renderCompletedApplication = () => (
+    <div className="bg-gray-50 p-4 rounded-lg">
+      <h4 className="font-medium mb-3">Completed Application</h4>
+      <div className="space-y-3">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Request Type</p>
+          <p className="text-sm text-gray-700">{requestTypeLabel}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Description</p>
+          <p className="text-sm text-gray-700 whitespace-pre-wrap">{request.description}</p>
+        </div>
+        {applicationItems.length > 0 && (
+          <div className="border-t border-gray-200 pt-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">
+              Application Responses
+            </p>
+            <div className="space-y-3">
+              {applicationItems.map((item, index) => (
+                <div key={`${item.label}-${index}`}>
+                  <p className="text-sm font-medium text-gray-800">{item.label}</p>
+                  <p className="text-sm text-gray-700 whitespace-pre-wrap">{item.value}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {request.attachments && request.attachments.length > 0 && (
+          <div className="border-t border-gray-200 pt-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">
+              Attachments ({request.attachments.length})
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {request.attachments.map((attachment) => (
+                <div
+                  key={attachment.id}
+                  className="flex items-center gap-2 bg-white rounded px-2 py-1"
+                >
+                  <span className="text-xs text-gray-700">{attachment.name}</span>
+                  <span className="text-xs text-gray-500">({attachment.size})</span>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-4 w-4 p-0"
+                    disabled={isDownloading === attachment.id}
+                    onClick={() => handleDownload(attachment.id, attachment.name)}
+                  >
+                    <Download className="h-3 w-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <Card className="p-4 border border-ashinaga-teal-100 rounded-lg">
       <CardContent className="p-0">
@@ -160,7 +232,9 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
             <div className="flex items-center gap-2 mb-2">
               <h4 className="font-medium text-gray-900">{request.scholarName}</h4>
               <Badge variant={getPriorityColor(request.priority)}>{request.priority}</Badge>
-              <Badge className={getStatusBadgeColor(request.status)}>{request.status}</Badge>
+              <Badge className={getStatusBadgeColor(request.status)}>
+                {getStatusLabel(request.status)}
+              </Badge>
             </div>
             <p className="text-sm text-gray-600 mb-2">{request.description}</p>
 
@@ -197,19 +271,22 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
             )}
 
             <div className="flex items-center gap-4 text-sm text-gray-500">
-              <span>Type: {request.type.replace('_', ' ')}</span>
+              <span>Type: {requestTypeLabel}</span>
               <span>Submitted: {new Date(request.submittedDate).toLocaleDateString()}</span>
             </div>
 
             {/* Show review details if already reviewed */}
             {(request.status === 'approved' ||
               request.status === 'rejected' ||
+              request.status === 'reviewed' ||
               request.status === 'commented') &&
               request.reviewComment && (
                 <div className="mt-3 p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center gap-2 mb-2">
                     <span className="text-sm font-medium text-gray-700">Review:</span>
-                    <Badge className={getStatusBadgeColor(request.status)}>{request.status}</Badge>
+                    <Badge className={getStatusBadgeColor(request.status)}>
+                      {getStatusLabel(request.status)}
+                    </Badge>
                   </div>
                   <p className="text-sm text-gray-600">{request.reviewComment}</p>
                   {request.reviewDate && (
@@ -233,50 +310,15 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                       Review
                     </Button>
                   </DialogTrigger>
-                  <DialogContent>
+                  <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
                     <DialogHeader>
                       <DialogTitle>Review Request</DialogTitle>
                       <DialogDescription>
-                        Approve or reject the request from {request.scholarName}
+                        Review the completed application from {request.scholarName}
                       </DialogDescription>
                     </DialogHeader>
                     <div className="space-y-4">
-                      <div className="bg-gray-50 p-4 rounded-lg">
-                        <h4 className="font-medium mb-2">Request Details</h4>
-                        <p className="text-sm text-gray-600 mb-2">
-                          <strong>Type:</strong> {request.type.replace('_', ' ')}
-                        </p>
-                        <p className="text-sm text-gray-600 mb-2">
-                          <strong>Description:</strong> {request.description}
-                        </p>
-                        {request.attachments && request.attachments.length > 0 && (
-                          <div className="mt-2">
-                            <p className="text-sm text-gray-600 mb-2">
-                              <strong>Attachments:</strong> {request.attachments.length} file(s)
-                            </p>
-                            <div className="flex flex-wrap gap-2">
-                              {request.attachments.map((attachment) => (
-                                <div
-                                  key={attachment.name}
-                                  className="flex items-center gap-2 bg-white rounded px-2 py-1"
-                                >
-                                  <span className="text-xs text-gray-700">{attachment.name}</span>
-                                  <span className="text-xs text-gray-500">({attachment.size})</span>
-                                  <Button
-                                    size="sm"
-                                    variant="ghost"
-                                    className="h-4 w-4 p-0"
-                                    disabled={isDownloading === attachment.id}
-                                    onClick={() => handleDownload(attachment.id, attachment.name)}
-                                  >
-                                    <Download className="h-3 w-3" />
-                                  </Button>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
+                      {renderCompletedApplication()}
                       <div>
                         <Label htmlFor="approvalComment">Comments (Optional)</Label>
                         <Textarea
@@ -300,6 +342,15 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                       >
                         <X className="h-4 w-4 mr-2" />
                         {isSubmitting ? 'Processing...' : 'Reject'}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => handleStatusUpdate('reviewed')}
+                        disabled={isSubmitting}
+                        className="text-purple-700 border-purple-200 hover:bg-purple-50"
+                      >
+                        <Clock className="h-4 w-4 mr-2" />
+                        {isSubmitting ? 'Processing...' : 'Reviewed'}
                       </Button>
                       <Button
                         onClick={() => handleApproval(true)}
@@ -326,6 +377,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
             {/* View Review Button for already reviewed requests */}
             {(request.status === 'approved' ||
               request.status === 'rejected' ||
+              request.status === 'reviewed' ||
               request.status === 'commented') && (
               <Dialog open={viewReviewOpen} onOpenChange={setViewReviewOpen}>
                 <DialogTrigger asChild>
@@ -334,7 +386,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                     View Review
                   </Button>
                 </DialogTrigger>
-                <DialogContent>
+                <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
                   <DialogHeader>
                     <DialogTitle>Review Details</DialogTitle>
                     <DialogDescription>
@@ -342,46 +394,12 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                     </DialogDescription>
                   </DialogHeader>
                   <div className="space-y-4">
-                    <div className="bg-gray-50 p-4 rounded-lg">
-                      <h4 className="font-medium mb-2">Request Details</h4>
-                      <p className="text-sm text-gray-600 mb-2">
-                        <strong>Type:</strong> {request.type.replace('_', ' ')}
-                      </p>
-                      <p className="text-sm text-gray-600 mb-2">
-                        <strong>Description:</strong> {request.description}
-                      </p>
-                      {request.attachments && request.attachments.length > 0 && (
-                        <div className="mt-2">
-                          <p className="text-sm text-gray-600 mb-2">
-                            <strong>Attachments:</strong> {request.attachments.length} file(s)
-                          </p>
-                          <div className="flex flex-wrap gap-2">
-                            {request.attachments.map((attachment) => (
-                              <div
-                                key={attachment.name}
-                                className="flex items-center gap-2 bg-white rounded px-2 py-1"
-                              >
-                                <span className="text-xs text-gray-700">{attachment.name}</span>
-                                <span className="text-xs text-gray-500">({attachment.size})</span>
-                                <Button
-                                  size="sm"
-                                  variant="ghost"
-                                  className="h-4 w-4 p-0"
-                                  onClick={() => handleDownload(attachment.url, attachment.name)}
-                                >
-                                  <Download className="h-3 w-3" />
-                                </Button>
-                              </div>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-                    </div>
+                    {renderCompletedApplication()}
                     <div>
                       <Label>Review Decision</Label>
                       <div className="mt-2">
                         <Badge className={getStatusBadgeColor(request.status)}>
-                          {request.status}
+                          {getStatusLabel(request.status)}
                         </Badge>
                       </div>
                     </div>

--- a/apps/staff/lib/api-client.ts
+++ b/apps/staff/lib/api-client.ts
@@ -545,9 +545,20 @@ export async function getFilterOptions(): Promise<ScholarFilterOptions> {
 // User management functions
 export interface UpdateUserData {
   name?: string;
+  image?: string | null;
 }
 
-export async function updateUser(data: UpdateUserData): Promise<any> {
+export interface UserProfile {
+  id: string;
+  name: string;
+  email: string;
+  image?: string | null;
+  userType?: 'staff' | 'scholar';
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export async function updateUser(data: UpdateUserData): Promise<UserProfile> {
   return fetchAPI('/api/users/me', {
     method: 'PATCH',
     headers: {

--- a/apps/staff/lib/api-client.ts
+++ b/apps/staff/lib/api-client.ts
@@ -465,6 +465,14 @@ export interface AnnouncementFilterOptions {
   statuses: string[];
 }
 
+export interface GetAnnouncementsParams {
+  year?: string;
+  program?: string;
+  university?: string;
+  status?: 'active' | 'archived' | 'all';
+  sortOrder?: 'asc' | 'desc';
+}
+
 export interface CreateAnnouncementData {
   title: string;
   content: string;
@@ -506,12 +514,30 @@ export interface Announcement {
   createdBy: string;
   createdAt: string;
   updatedAt: string;
+  archived: boolean;
+  archivedAt?: string | null;
   filters: Array<{ type: string; value: string }>;
   recipientCount: number;
 }
 
-export async function getAnnouncements(): Promise<Announcement[]> {
-  return fetchAPI<Announcement[]>('/api/announcements');
+export async function getAnnouncements(params?: GetAnnouncementsParams): Promise<Announcement[]> {
+  const queryParams = new URLSearchParams();
+
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (
+        value !== undefined &&
+        value !== null &&
+        value !== '' &&
+        (key === 'status' || value !== 'all')
+      ) {
+        queryParams.append(key, String(value));
+      }
+    });
+  }
+
+  const queryString = queryParams.toString();
+  return fetchAPI<Announcement[]>(`/api/announcements${queryString ? `?${queryString}` : ''}`);
 }
 
 export async function deleteAnnouncement(announcementId: string): Promise<void> {

--- a/apps/staff/lib/hooks/use-queries.ts
+++ b/apps/staff/lib/hooks/use-queries.ts
@@ -1,10 +1,11 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
-  type CreateTaskData,
   archiveScholar,
+  type CreateTaskData,
   createAnnouncement,
   createTask,
   deleteScholar,
+  type GetAnnouncementsParams,
   getAnnouncements,
   getScholarProfile,
   getTasksByScholar,
@@ -21,7 +22,7 @@ export const queryKeys = {
   scholarProfile: (id: string) => ['scholar', id, 'profile'] as const,
   scholarTasks: (id: string) => ['scholar', id, 'tasks'] as const,
   user: ['user'] as const,
-  announcements: ['announcements'] as const,
+  announcements: (params?: GetAnnouncementsParams) => ['announcements', params] as const,
 };
 
 // Scholar profile query
@@ -83,10 +84,10 @@ export function useUpdateUser() {
 }
 
 // Announcements query
-export function useAnnouncements(enabled = true) {
+export function useAnnouncements(params?: GetAnnouncementsParams, enabled = true) {
   return useQuery({
-    queryKey: queryKeys.announcements,
-    queryFn: getAnnouncements,
+    queryKey: queryKeys.announcements(params),
+    queryFn: () => getAnnouncements(params),
     enabled,
   });
 }
@@ -100,7 +101,7 @@ export function useCreateAnnouncement() {
     onSuccess: () => {
       // Invalidate and refetch announcements
       queryClient.invalidateQueries({
-        queryKey: queryKeys.announcements,
+        queryKey: ['announcements'],
       });
     },
   });


### PR DESCRIPTION
## Summary

- Added announcement list filtering by year, program, university, and status for staff.
- Added announcement date sorting with most recent and oldest first options.
- Added scholar announcement filtering by year, program, and university using announcement targeting metadata.
- Updated announcement API query params and React Query keys so filter/sort changes refetch cleanly.

## PR Checklist (Skills)

- [x] N/A: This PR does not add or change a skill package (`packages/*` with `SKILL.md`).
- [x] N/A: Skill wrapper behavior not applicable.
- [x] N/A: `.env.example` changes not applicable.
- [x] N/A: `SKILL.md` env setup not applicable.
- [ ] `pnpm check:skills` passes locally.
- [ ] `pnpm lint` passes locally.

## Validation Notes

- `pnpm check:skills`: Not run; PR does not touch skill packages.
- `pnpm lint`: Targeted Biome checks passed for touched files.
- `pnpm dev` (root) outcome: Not run; repo instructions say not to start dev servers.
- Additional validation:
  - `corepack pnpm --filter ashinaga-api build`: passed
  - `corepack pnpm --filter staff typecheck`: passed
  - `corepack pnpm --filter scholar typecheck`: passed
  - `corepack pnpm --filter ashinaga-api test -- announcements`: passed