### PR TITLE
ASH-55 Fix scholar onboarding payload contract

### DIFF
--- a/apps/api/src/scholars/scholars.service.spec.ts
+++ b/apps/api/src/scholars/scholars.service.spec.ts
@@ -31,21 +31,26 @@ jest.mock('../auth/auth.config', () => ({
 }));
 
 import { InvitationsService } from '../invitations/invitations.service';
+import type { CreateScholarDto } from './dto/create-scholar.dto';
+import { Gender } from './dto/update-scholar-profile.dto';
 import { ScholarsService } from './scholars.service';
 
 describe('ScholarsService', () => {
   let service: ScholarsService;
   let mockDatabase: { select: jest.Mock };
+  let mockInvitationsService: { createInvitation: jest.Mock };
 
   beforeEach(async () => {
+    mockInvitationsService = {
+      createInvitation: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ScholarsService,
         {
           provide: InvitationsService,
-          useValue: {
-            createInvitation: jest.fn(),
-          },
+          useValue: mockInvitationsService,
         },
       ],
     }).compile();
@@ -56,6 +61,44 @@ describe('ScholarsService', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('createScholar', () => {
+    it('should preserve onboarding-only fields in the invitation scholar data', async () => {
+      const mockLimit = jest.fn().mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+      const mockWhere = jest.fn().mockReturnValue({ limit: mockLimit });
+      const mockFrom = jest.fn().mockReturnValue({ where: mockWhere });
+
+      mockDatabase.select = jest.fn().mockReturnValue({ from: mockFrom });
+      mockInvitationsService.createInvitation.mockResolvedValue({ id: 'invitation-1' });
+
+      const createScholarDto: CreateScholarDto = {
+        name: 'Test Scholar',
+        email: 'Scholar@Example.com',
+        program: 'Undergraduate',
+        year: 'Year 1',
+        university: 'University of Test',
+        startDate: '2026-09-01',
+        gender: Gender.MALE,
+        majorCategory: 'Engineering',
+        fieldOfStudy: 'CS',
+      };
+
+      await service.createScholar(createScholarDto, 'staff-1');
+
+      expect(mockInvitationsService.createInvitation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'scholar@example.com',
+          userType: 'scholar',
+          scholarData: expect.objectContaining({
+            gender: 'male',
+            majorCategory: 'Engineering',
+            fieldOfStudy: 'CS',
+          }),
+        }),
+        'staff-1'
+      );
+    });
   });
 
   describe('getScholars', () => {
@@ -548,7 +591,7 @@ describe('ScholarsService', () => {
         documents: [],
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
-      } as any);
+      } as Awaited<ReturnType<ScholarsService['updateScholarProfile']>>);
 
       const updateData = { phone: '+15551234567', program: 'CS' };
       const result = await service.updateScholarProfileByScholarId('scholar-1', updateData);
@@ -697,7 +740,7 @@ describe('ScholarsService', () => {
         tasks: { total: 0, completed: 0, overdue: 0 },
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
-      } as any);
+      } as Awaited<ReturnType<ScholarsService['getScholar']>>);
 
       const result = await service.archiveScholar('s1');
 

--- a/apps/api/src/scholars/scholars.service.ts
+++ b/apps/api/src/scholars/scholars.service.ts
@@ -109,6 +109,8 @@ export class ScholarsService {
         postGraduationPlan: createScholarDto.postGraduationPlan,
         startDate: createScholarDto.startDate,
         graduationDate: createScholarDto.graduationDate,
+        majorCategory: createScholarDto.majorCategory,
+        fieldOfStudy: createScholarDto.fieldOfStudy,
       },
     };
 

--- a/apps/staff/components/scholar-onboarding.tsx
+++ b/apps/staff/components/scholar-onboarding.tsx
@@ -11,7 +11,8 @@ import {
 } from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
-import { createScholar } from '../lib/api-client';
+import { type CreateScholarData, createScholar } from '../lib/api-client';
+import { GENDER_OPTIONS, type Gender } from '../lib/constants';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
@@ -30,7 +31,7 @@ interface ScholarData {
   name: string;
   aaiScholarId: string;
   dateOfBirth: string;
-  gender: string;
+  gender: Gender | '';
   nationality: string;
   phone: string;
   email: string;
@@ -235,7 +236,6 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
   const [step, setStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
-  const [fieldOfStudySearch, setFieldOfStudySearch] = useState('');
 
   const handleInputChange = (field: keyof ScholarData, value: string) => {
     setScholarData((prev) => ({ ...prev, [field]: value }));
@@ -349,12 +349,9 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
     console.log('Submitting scholar data:', scholarData);
 
     // Clean up the data - remove empty strings for optional fields
-    const cleanedData: any = {};
-    Object.entries(scholarData).forEach(([key, value]) => {
-      if (value !== '' && value !== undefined && value !== null) {
-        cleanedData[key] = value;
-      }
-    });
+    const cleanedData = Object.fromEntries(
+      Object.entries(scholarData).filter(([, value]) => value !== '' && value !== undefined)
+    ) as CreateScholarData;
 
     console.log('Cleaned scholar data:', cleanedData);
 
@@ -366,13 +363,13 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
       } else {
         console.error('Failed to create scholar:', result);
         // Show specific error message if available
-        const errorMessage =
-          (result as any).message || 'Failed to create scholar. Please try again.';
+        const errorMessage = result.message || 'Failed to create scholar. Please try again.';
         setValidationErrors({ submit: errorMessage });
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error creating scholar:', error);
-      const errorMessage = error?.message || 'Error creating scholar. Please try again.';
+      const errorMessage =
+        error instanceof Error ? error.message : 'Error creating scholar. Please try again.';
       setValidationErrors({ submit: errorMessage });
     } finally {
       setIsSubmitting(false);
@@ -544,16 +541,17 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
                     <Label htmlFor="gender">Gender</Label>
                     <Select
                       value={scholarData.gender}
-                      onValueChange={(value) => handleInputChange('gender', value)}
+                      onValueChange={(value) => handleInputChange('gender', value as Gender)}
                     >
                       <SelectTrigger>
                         <SelectValue placeholder="Select gender" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="male">Male</SelectItem>
-                        <SelectItem value="female">Female</SelectItem>
-                        <SelectItem value="other">Other</SelectItem>
-                        <SelectItem value="prefer_not_to_say">Prefer not to say</SelectItem>
+                        {GENDER_OPTIONS.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
                   </div>

--- a/apps/staff/components/scholar-onboarding.tsx
+++ b/apps/staff/components/scholar-onboarding.tsx
@@ -267,7 +267,7 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
           name: 'John Doe',
           aaiScholarId: 'AAI123',
           dateOfBirth: '2000-01-01',
-          gender: 'Male',
+          gender: 'male',
           nationality: 'British',
           phone: '+44 7123 456789',
           email: 'john.doe@scholar.ac.uk',
@@ -295,7 +295,7 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
           name: 'Jane Smith',
           aaiScholarId: 'AAI456',
           dateOfBirth: '2001-02-02',
-          gender: 'Female',
+          gender: 'female',
           nationality: 'American',
           phone: '+44 7234 567890',
           email: 'jane.smith@scholar.ac.uk',
@@ -550,9 +550,10 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
                         <SelectValue placeholder="Select gender" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="Male">Male</SelectItem>
-                        <SelectItem value="Female">Female</SelectItem>
-                        <SelectItem value="Other">Other</SelectItem>
+                        <SelectItem value="male">Male</SelectItem>
+                        <SelectItem value="female">Female</SelectItem>
+                        <SelectItem value="other">Other</SelectItem>
+                        <SelectItem value="prefer_not_to_say">Prefer not to say</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/apps/staff/components/scholar-profile.tsx
+++ b/apps/staff/components/scholar-profile.tsx
@@ -29,6 +29,7 @@ import {
   COUNTRY_OPTIONS,
   DEFAULT_UNIVERSITY_OPTIONS,
   GENDER_OPTIONS,
+  type Gender,
   normalizeLocation,
   normalizeNationality,
 } from '../lib/constants';
@@ -295,7 +296,7 @@ export function ScholarProfilePage({
                           gender:
                             value === '_none'
                               ? undefined
-                              : (value as 'male' | 'female' | 'other' | 'prefer_not_to_say'),
+                              : (value as Gender),
                         }))
                       }
                     >

--- a/apps/staff/lib/api-client.ts
+++ b/apps/staff/lib/api-client.ts
@@ -1,6 +1,8 @@
 // API client for making authenticated requests to the backend
 // Works alongside better-auth for non-auth endpoints
 
+import type { Gender } from './constants';
+
 export interface ScholarGoalsStats {
   total: number;
   completed: number;
@@ -118,7 +120,7 @@ export interface ScholarProfile {
   lastActivity?: string | null;
   aaiScholarId?: string | null;
   dateOfBirth?: string | null;
-  gender?: 'male' | 'female' | 'other' | 'prefer_not_to_say' | null;
+  gender?: Gender | null;
   nationality?: string | null;
   addressHomeCountry?: string | null;
   passportExpirationDate?: string | null;
@@ -142,7 +144,7 @@ export interface ScholarProfile {
 
 export interface UpdateScholarProfileData {
   dateOfBirth?: string;
-  gender?: string;
+  gender?: Gender;
   nationality?: string;
   phone?: string;
   location?: string;
@@ -354,7 +356,7 @@ export interface Request {
     | 'summer_funding_report'
     | 'requirement_submission';
   description: string;
-  formData?: Record<string, any> | null;
+  formData?: Record<string, unknown> | null;
   priority: 'high' | 'medium' | 'low';
   status: 'pending' | 'approved' | 'rejected' | 'reviewed' | 'commented';
   submittedDate: string;
@@ -669,7 +671,7 @@ export interface CreateScholarData {
   startDate: string;
   aaiScholarId?: string;
   dateOfBirth?: string;
-  gender?: string;
+  gender?: Gender;
   nationality?: string;
   phone?: string;
   location?: string;
@@ -685,12 +687,14 @@ export interface CreateScholarData {
   longTermCareerPlan?: string;
   postGraduationPlan?: string;
   bio?: string;
+  majorCategory?: string;
+  fieldOfStudy?: string;
 }
 
 export async function createScholar(data: CreateScholarData): Promise<{
   success: boolean;
   message: string;
-  scholar?: any;
+  scholar?: unknown;
 }> {
   return fetchAPI('/api/scholars', {
     method: 'POST',

--- a/apps/staff/lib/constants.ts
+++ b/apps/staff/lib/constants.ts
@@ -3,7 +3,9 @@
  * Kept in sync with scholar app where applicable.
  */
 
-export const GENDER_OPTIONS = [
+export type Gender = 'male' | 'female' | 'other' | 'prefer_not_to_say';
+
+export const GENDER_OPTIONS: readonly { value: Gender; label: string }[] = [
   { value: 'male', label: 'Male' },
   { value: 'female', label: 'Female' },
   { value: 'other', label: 'Other' },


### PR DESCRIPTION
## Summary

- Fixed scholar onboarding gender values so the staff form submits API-compatible enum values while keeping readable labels in the UI.
- Preserved Major Category and Field of Study through the scholar invitation/signup payload.
- Updated mock CSV preview gender values to match the backend contract.

## PR Checklist

- [ ] `pnpm check:skills` passes locally.
- [ ] `pnpm lint` passes locally.

## Validation Notes

- `pnpm check:skills`: Not run; this PR does not add or change a skill package.
- `pnpm lint`: Not run globally.

Additional validation:
- `corepack pnpm --filter staff typecheck`: Passed.
- `corepack pnpm --dir apps\api build`: Passed.