### PR TITLE
Ash 56 add dark mode to staff portal

### DIFF
--- a/apps/staff/app/globals.css
+++ b/apps/staff/app/globals.css
@@ -45,38 +45,39 @@
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
+    /* Match the scholar portal's blue-black dark mode palette. */
+    --background: 222 47% 11%;
+    --foreground: 210 40% 98%;
+    --card: 217 33% 17%;
+    --card-foreground: 210 40% 98%;
+    --popover: 217 33% 17%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 217 33% 22%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 217 33% 20%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 217 33% 22%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 45%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --border: 217 33% 24%;
+    --input: 217 33% 20%;
+    --ring: 199 89% 48%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-    --sidebar-background: 240 5.9% 10%;
-    --sidebar-foreground: 240 4.8% 95.9%;
-    --sidebar-primary: 224.3 76.3% 48%;
+    --sidebar-background: 222 47% 9%;
+    --sidebar-foreground: 210 40% 98%;
+    --sidebar-primary: 199 89% 48%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 240 3.7% 15.9%;
-    --sidebar-accent-foreground: 240 4.8% 95.9%;
-    --sidebar-border: 240 3.7% 15.9%;
-    --sidebar-ring: 217.2 91.2% 59.8%;
+    --sidebar-accent: 217 33% 22%;
+    --sidebar-accent-foreground: 210 40% 98%;
+    --sidebar-border: 217 33% 24%;
+    --sidebar-ring: 199 89% 48%;
   }
 }
 

--- a/apps/staff/app/layout.tsx
+++ b/apps/staff/app/layout.tsx
@@ -1,6 +1,7 @@
 import { GeistMono } from 'geist/font/mono';
 import { GeistSans } from 'geist/font/sans';
 import type { Metadata } from 'next';
+import { ThemeProvider } from '../components/theme-provider';
 import { QueryProvider } from '../lib/query-client';
 import './globals.css';
 
@@ -15,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <style>{`
 html {
@@ -26,7 +27,14 @@ html {
         `}</style>
       </head>
       <body suppressHydrationWarning>
-        <QueryProvider>{children}</QueryProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <QueryProvider>{children}</QueryProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -12,6 +12,7 @@ import { ScholarOnboarding } from '../components/scholar-onboarding';
 import { ScholarProfilePage } from '../components/scholar-profile';
 import { StaffInviteDialog } from '../components/staff-invite-dialog';
 import { TaskAssignment } from '../components/task-assignment';
+import { ThemeToggle } from '../components/theme-toggle';
 import { Avatar, AvatarFallback, AvatarImage } from '../components/ui/avatar';
 import { Badge } from '../components/ui/badge';
 import { Button } from '../components/ui/button';
@@ -166,19 +167,19 @@ function StaffDashboardContent() {
   const _getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'text-green-600';
+        return 'text-green-600 dark:text-green-400';
       case 'approved':
-        return 'text-green-600';
+        return 'text-green-600 dark:text-green-400';
       case 'in-progress':
-        return 'text-blue-600';
+        return 'text-blue-600 dark:text-blue-400';
       case 'pending':
         return 'text-orange-600';
       case 'reviewed':
-        return 'text-purple-600';
+        return 'text-purple-600 dark:text-purple-400';
       case 'rejected':
         return 'text-red-600';
       default:
-        return 'text-gray-600';
+        return 'text-muted-foreground';
     }
   };
 
@@ -300,12 +301,12 @@ function StaffDashboardContent() {
   // Show loading state while checking authentication
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background flex items-center justify-center">
         <div className="text-center">
           <div className="w-16 h-16 bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 rounded-lg flex items-center justify-center mx-auto mb-4 animate-pulse">
             <span className="text-white font-bold text-2xl">A</span>
           </div>
-          <p className="text-gray-600">Loading...</p>
+          <p className="text-muted-foreground">Loading...</p>
         </div>
       </div>
     );
@@ -317,20 +318,21 @@ function StaffDashboardContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50">
+    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background">
       {/* Header */}
-      <header className="bg-white border-b border-ashinaga-teal-100 px-6 py-4">
+      <header className="bg-card border-b border-border px-6 py-4">
         <div className="flex items-center justify-between max-w-7xl mx-auto">
           <div className="flex items-center gap-4">
             <div className="w-10 h-10 bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 rounded-lg flex items-center justify-center">
               <span className="text-white font-bold text-lg">A</span>
             </div>
             <div>
-              <h1 className="text-xl font-semibold text-gray-900">Ashinaga Staff Portal</h1>
-              <p className="text-sm text-gray-600">Supporting Scholar Success</p>
+              <h1 className="text-xl font-semibold text-foreground">Ashinaga Staff Portal</h1>
+              <p className="text-sm text-muted-foreground">Supporting Scholar Success</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
+            <ThemeToggle />
             <Button variant="ghost" size="sm" onClick={() => router.push('?view=my-profile')}>
               My Profile
             </Button>
@@ -380,20 +382,20 @@ function StaffDashboardContent() {
               {/* Stats Overview */}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <Card
-                  className="cursor-pointer hover:shadow-md transition-shadow"
+                  className="cursor-pointer border-border hover:shadow-md transition-shadow"
                   onClick={navigateToScholars}
                 >
                   <CardContent className="pt-6">
                     <div className="flex items-center">
                       <div className="flex-1">
-                        <p className="text-sm font-medium text-gray-600">Total Scholars</p>
+                        <p className="text-sm font-medium text-muted-foreground">Total Scholars</p>
                         {scholarStatsLoading ? (
                           <div className="flex items-center gap-2">
                             <Loader2 className="h-4 w-4 animate-spin" />
-                            <span className="text-2xl font-bold text-gray-900">Loading...</span>
+                            <span className="text-2xl font-bold text-foreground">Loading...</span>
                           </div>
                         ) : (
-                          <p className="text-2xl font-bold text-gray-900">
+                          <p className="text-2xl font-bold text-foreground">
                             {scholarStats?.total || 0}
                           </p>
                         )}
@@ -401,28 +403,30 @@ function StaffDashboardContent() {
                           {scholarStats?.active || 0} active
                         </p>
                       </div>
-                      <div className="w-12 h-12 bg-gradient-to-r from-ashinaga-teal-100 to-ashinaga-green-100 rounded-lg flex items-center justify-center">
-                        <Users className="h-6 w-6 text-ashinaga-teal-600" />
+                      <div className="w-12 h-12 bg-gradient-to-r from-ashinaga-teal-100 to-ashinaga-green-100 dark:from-ashinaga-teal-900/40 dark:to-ashinaga-green-900/40 rounded-lg flex items-center justify-center">
+                        <Users className="h-6 w-6 text-ashinaga-teal-600 dark:text-ashinaga-teal-400" />
                       </div>
                     </div>
                   </CardContent>
                 </Card>
 
                 <Card
-                  className="cursor-pointer hover:shadow-md transition-shadow"
+                  className="cursor-pointer border-border hover:shadow-md transition-shadow"
                   onClick={navigateToRequests}
                 >
                   <CardContent className="pt-6">
                     <div className="flex items-center">
                       <div className="flex-1">
-                        <p className="text-sm font-medium text-gray-600">Pending Requests</p>
+                        <p className="text-sm font-medium text-muted-foreground">
+                          Pending Requests
+                        </p>
                         {requestStatsLoading ? (
                           <div className="flex items-center gap-2">
                             <Loader2 className="h-4 w-4 animate-spin" />
-                            <span className="text-2xl font-bold text-gray-900">Loading...</span>
+                            <span className="text-2xl font-bold text-foreground">Loading...</span>
                           </div>
                         ) : (
-                          <p className="text-2xl font-bold text-gray-900">
+                          <p className="text-2xl font-bold text-foreground">
                             {requestStats?.pending || 0}
                           </p>
                         )}
@@ -430,8 +434,8 @@ function StaffDashboardContent() {
                           {requestStats?.total || 0} total requests
                         </p>
                       </div>
-                      <div className="w-12 h-12 bg-gradient-to-r from-orange-100 to-red-100 rounded-lg flex items-center justify-center">
-                        <AlertCircle className="h-6 w-6 text-orange-600" />
+                      <div className="w-12 h-12 bg-gradient-to-r from-orange-100 to-red-100 dark:from-orange-900/30 dark:to-red-900/30 rounded-lg flex items-center justify-center">
+                        <AlertCircle className="h-6 w-6 text-orange-600 dark:text-orange-400" />
                       </div>
                     </div>
                   </CardContent>
@@ -439,7 +443,7 @@ function StaffDashboardContent() {
               </div>
 
               {/* Quick Actions */}
-              <Card>
+              <Card className="border-border">
                 <CardHeader>
                   <CardTitle className="flex items-center gap-2">
                     <Plus className="h-5 w-5" />
@@ -462,7 +466,7 @@ function StaffDashboardContent() {
                       trigger={
                         <Button
                           variant="outline"
-                          className="h-20 flex-col gap-2 border-ashinaga-teal-200 hover:bg-ashinaga-teal-50 bg-transparent w-full"
+                          className="h-20 flex-col gap-2 border-ashinaga-teal-200 dark:border-border hover:bg-ashinaga-teal-50 dark:hover:bg-muted bg-transparent w-full"
                         >
                           <FileText className="h-6 w-6" />
                           Assign Task to Scholar
@@ -477,7 +481,7 @@ function StaffDashboardContent() {
                     />
                     <Button
                       variant="outline"
-                      className="h-20 flex-col gap-2 border-ashinaga-teal-200 hover:bg-ashinaga-teal-50 bg-transparent"
+                      className="h-20 flex-col gap-2 border-ashinaga-teal-200 dark:border-border hover:bg-ashinaga-teal-50 dark:hover:bg-muted bg-transparent"
                       onClick={() => router.push('?tab=announcements')}
                     >
                       <MessageSquare className="h-6 w-6" />
@@ -485,7 +489,7 @@ function StaffDashboardContent() {
                     </Button>
                     <Button
                       variant="outline"
-                      className="h-20 flex-col gap-2 border-ashinaga-teal-200 hover:bg-ashinaga-teal-50 bg-transparent"
+                      className="h-20 flex-col gap-2 border-ashinaga-teal-200 dark:border-border hover:bg-ashinaga-teal-50 dark:hover:bg-muted bg-transparent"
                       onClick={() => router.push('?tab=requests')}
                     >
                       <FileText className="h-6 w-6" />
@@ -507,7 +511,7 @@ function StaffDashboardContent() {
                   }}
                 />
               ) : (
-                <Card>
+                <Card className="border-border">
                   <CardHeader>
                     <CardTitle>Scholar Management</CardTitle>
                     <CardDescription>View and manage your assigned scholars</CardDescription>
@@ -525,7 +529,7 @@ function StaffDashboardContent() {
             </TabsContent>
 
             <TabsContent value="requests" className="space-y-6">
-              <Card>
+              <Card className="border-border">
                 <CardHeader>
                   <div className="flex items-center justify-between">
                     <div>
@@ -583,7 +587,7 @@ function StaffDashboardContent() {
                       <p className="text-red-600">{requestsError}</p>
                     </div>
                   ) : requests.length === 0 ? (
-                    <div className="text-center py-12 text-gray-500">
+                    <div className="text-center py-12 text-muted-foreground">
                       <MessageSquare className="h-12 w-12 mx-auto mb-4 opacity-50" />
                       <p>No requests found</p>
                     </div>
@@ -603,7 +607,7 @@ function StaffDashboardContent() {
             </TabsContent>
 
             <TabsContent value="announcements" className="space-y-6">
-              <Card>
+              <Card className="border-border">
                 <CardHeader>
                   <div className="flex items-center justify-between">
                     <div>
@@ -711,7 +715,7 @@ function StaffDashboardContent() {
                       </p>
                     </div>
                   ) : announcements.length === 0 ? (
-                    <div className="text-center py-12 text-gray-500">
+                    <div className="text-center py-12 text-muted-foreground">
                       <MessageSquare className="h-12 w-12 mx-auto mb-4 opacity-50" />
                       <p>No announcements match the current filters.</p>
                     </div>
@@ -722,11 +726,11 @@ function StaffDashboardContent() {
                           <div className="flex items-start justify-between gap-4">
                             <div className="flex-1">
                               <h3 className="font-semibold text-lg mb-2">{announcement.title}</h3>
-                              <p className="text-gray-600 mb-3 whitespace-pre-wrap">
+                              <p className="text-muted-foreground mb-3 whitespace-pre-wrap">
                                 {announcement.content}
                               </p>
                               <div className="flex items-center justify-between">
-                                <div className="flex items-center text-sm text-gray-500">
+                                <div className="flex items-center text-sm text-muted-foreground">
                                   <span>By {announcement.createdBy}</span>
                                   <span className="mx-2">•</span>
                                   <span>

--- a/apps/staff/components/announcement-creator.tsx
+++ b/apps/staff/components/announcement-creator.tsx
@@ -203,7 +203,7 @@ export function AnnouncementCreator({ trigger }: AnnouncementCreatorProps) {
               rows={8}
               className="resize-none"
             />
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted-foreground">
               Basic formatting supported. For rich text editing, we'll add a WYSIWYG editor in the
               next update.
             </p>
@@ -283,7 +283,7 @@ export function AnnouncementCreator({ trigger }: AnnouncementCreatorProps) {
                 )}
 
                 {filters.length === 0 && (
-                  <p className="text-sm text-gray-500 italic">
+                  <p className="text-sm text-muted-foreground italic">
                     No filters applied - announcement will be sent to all students
                   </p>
                 )}
@@ -301,7 +301,7 @@ export function AnnouncementCreator({ trigger }: AnnouncementCreatorProps) {
               </CardHeader>
               <CardContent>
                 {loading ? (
-                  <div className="text-center py-8 text-gray-500">
+                  <div className="text-center py-8 text-muted-foreground">
                     <p>Loading scholars...</p>
                   </div>
                 ) : previewStudents.length > 0 ? (
@@ -328,7 +328,7 @@ export function AnnouncementCreator({ trigger }: AnnouncementCreatorProps) {
                     </Table>
                   </div>
                 ) : (
-                  <div className="text-center py-8 text-gray-500">
+                  <div className="text-center py-8 text-muted-foreground">
                     <p>No students match the current filters</p>
                   </div>
                 )}

--- a/apps/staff/components/forgot-password-page.tsx
+++ b/apps/staff/components/forgot-password-page.tsx
@@ -48,7 +48,7 @@ export function ForgotPasswordPage() {
 
   if (success) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background flex items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
             <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -60,8 +60,8 @@ export function ForgotPasswordPage() {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <p className="text-sm text-blue-800">
+            <div className="bg-muted border border-border rounded-lg p-4">
+              <p className="text-sm text-muted-foreground">
                 The reset link will expire in 1 hour. If you don't see the email, check your spam
                 folder.
               </p>
@@ -91,7 +91,7 @@ export function ForgotPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="w-16 h-16 bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 rounded-lg flex items-center justify-center mx-auto mb-4">
@@ -114,7 +114,7 @@ export function ForgotPasswordPage() {
             <div className="space-y-2">
               <Label htmlFor="email">Email Address</Label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                 <Input
                   id="email"
                   type="email"
@@ -140,7 +140,7 @@ export function ForgotPasswordPage() {
           <div className="text-center">
             <Link
               href="/login"
-              className="text-sm text-gray-600 hover:text-gray-800 inline-flex items-center"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center"
             >
               <ArrowLeft className="h-3 w-3 mr-1" />
               Back to Sign In

--- a/apps/staff/components/login-page.tsx
+++ b/apps/staff/components/login-page.tsx
@@ -53,7 +53,7 @@ export function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="w-16 h-16 bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 rounded-lg flex items-center justify-center mx-auto mb-4">
@@ -71,7 +71,9 @@ export function LoginPage() {
                 <p className="text-sm text-orange-600">This portal is for staff members only</p>
               </div>
               <div className="text-center">
-                <p className="text-sm text-gray-600 mb-2">Looking for the Scholar Portal?</p>
+                <p className="text-sm text-muted-foreground mb-2">
+                  Looking for the Scholar Portal?
+                </p>
                 <Button
                   variant="outline"
                   size="sm"
@@ -86,10 +88,10 @@ export function LoginPage() {
               </div>
               <div className="relative">
                 <div className="absolute inset-0 flex items-center">
-                  <span className="w-full border-t border-gray-300" />
+                  <span className="w-full border-t border-border" />
                 </div>
                 <div className="relative flex justify-center text-xs uppercase">
-                  <span className="bg-white px-2 text-gray-500">Or sign in as staff</span>
+                  <span className="bg-card px-2 text-muted-foreground">Or sign in as staff</span>
                 </div>
               </div>
             </div>
@@ -139,7 +141,7 @@ export function LoginPage() {
             <div className="space-y-2">
               <Label htmlFor="email">Email</Label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                <Mail className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                 <Input
                   id="email"
                   type="email"
@@ -150,13 +152,15 @@ export function LoginPage() {
                   required
                 />
               </div>
-              <p className="text-xs text-gray-500">You must have an invitation to sign in</p>
+              <p className="text-xs text-muted-foreground">
+                You must have an invitation to sign in
+              </p>
             </div>
 
             <div className="space-y-2">
               <Label htmlFor="password">Password</Label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                 <Input
                   id="password"
                   type={showPassword ? 'text' : 'password'}
@@ -174,9 +178,9 @@ export function LoginPage() {
                   onClick={() => setShowPassword(!showPassword)}
                 >
                   {showPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-400" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-400" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -193,7 +197,7 @@ export function LoginPage() {
 
           <div className="text-center space-y-2">
             <div>
-              <span className="text-sm text-gray-600">Don't have an account? </span>
+              <span className="text-sm text-muted-foreground">Don't have an account? </span>
               <Button
                 variant="link"
                 className="p-0 h-auto text-sm font-normal text-ashinaga-teal hover:text-ashinaga-teal/80"
@@ -205,7 +209,7 @@ export function LoginPage() {
             <div>
               <Button
                 variant="link"
-                className="text-sm text-gray-600"
+                className="text-sm text-muted-foreground"
                 onClick={() => router.push('/forgot-password')}
               >
                 Forgot your password?

--- a/apps/staff/components/my-profile.tsx
+++ b/apps/staff/components/my-profile.tsx
@@ -173,7 +173,7 @@ export function MyProfile({ onBack }: MyProfileProps) {
             )}
             <div>
               <h3 className="text-lg font-medium">{profileData.name}</h3>
-              <p className="text-sm text-gray-600">{profileData.email}</p>
+              <p className="text-sm text-muted-foreground">{profileData.email}</p>
               {isEditing && (
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                   <Button asChild variant="outline" size="sm">

--- a/apps/staff/components/request-management.tsx
+++ b/apps/staff/components/request-management.tsx
@@ -144,17 +144,17 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
   const getStatusBadgeColor = (status: string) => {
     switch (status) {
       case 'approved':
-        return 'bg-green-100 text-green-800';
+        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
       case 'rejected':
         return 'bg-red-100 text-red-800';
       case 'pending':
         return 'bg-orange-100 text-orange-800';
       case 'reviewed':
-        return 'bg-purple-100 text-purple-800';
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300';
       case 'commented':
-        return 'bg-blue-100 text-blue-800';
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
       default:
-        return 'bg-gray-100 text-gray-800';
+        return 'bg-muted text-foreground';
     }
   };
 
@@ -168,45 +168,49 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
   const canMakeDecision = request.status === 'pending' || request.status === 'reviewed';
 
   const renderCompletedApplication = () => (
-    <div className="bg-gray-50 p-4 rounded-lg">
+    <div className="bg-muted p-4 rounded-lg">
       <h4 className="font-medium mb-3">Completed Application</h4>
       <div className="space-y-3">
         <div>
-          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Request Type</p>
-          <p className="text-sm text-gray-700">{requestTypeLabel}</p>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Request Type
+          </p>
+          <p className="text-sm text-foreground">{requestTypeLabel}</p>
         </div>
         <div>
-          <p className="text-xs font-medium uppercase tracking-wide text-gray-500">Description</p>
-          <p className="text-sm text-gray-700 whitespace-pre-wrap">{request.description}</p>
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Description
+          </p>
+          <p className="text-sm text-foreground whitespace-pre-wrap">{request.description}</p>
         </div>
         {applicationItems.length > 0 && (
-          <div className="border-t border-gray-200 pt-3">
-            <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">
+          <div className="border-t border-border pt-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
               Application Responses
             </p>
             <div className="space-y-3">
               {applicationItems.map((item, index) => (
                 <div key={`${item.label}-${index}`}>
-                  <p className="text-sm font-medium text-gray-800">{item.label}</p>
-                  <p className="text-sm text-gray-700 whitespace-pre-wrap">{item.value}</p>
+                  <p className="text-sm font-medium text-foreground">{item.label}</p>
+                  <p className="text-sm text-foreground whitespace-pre-wrap">{item.value}</p>
                 </div>
               ))}
             </div>
           </div>
         )}
         {request.attachments && request.attachments.length > 0 && (
-          <div className="border-t border-gray-200 pt-3">
-            <p className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-2">
+          <div className="border-t border-border pt-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
               Attachments ({request.attachments.length})
             </p>
             <div className="flex flex-wrap gap-2">
               {request.attachments.map((attachment) => (
                 <div
                   key={attachment.id}
-                  className="flex items-center gap-2 bg-white rounded px-2 py-1"
+                  className="flex items-center gap-2 bg-background rounded px-2 py-1"
                 >
-                  <span className="text-xs text-gray-700">{attachment.name}</span>
-                  <span className="text-xs text-gray-500">({attachment.size})</span>
+                  <span className="text-xs text-foreground">{attachment.name}</span>
+                  <span className="text-xs text-muted-foreground">({attachment.size})</span>
                   <Button
                     size="sm"
                     variant="ghost"
@@ -226,25 +230,25 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
   );
 
   return (
-    <Card className="p-4 border border-ashinaga-teal-100 rounded-lg">
+    <Card className="p-4 border border-border rounded-lg">
       <CardContent className="p-0">
         <div className="flex items-start justify-between">
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-2">
-              <h4 className="font-medium text-gray-900">{request.scholarName}</h4>
+              <h4 className="font-medium text-foreground">{request.scholarName}</h4>
               <Badge variant={getPriorityColor(request.priority)}>{request.priority}</Badge>
               <Badge className={getStatusBadgeColor(request.status)}>
                 {getStatusLabel(request.status)}
               </Badge>
             </div>
-            <p className="text-sm text-gray-600 mb-2">{request.description}</p>
+            <p className="text-sm text-muted-foreground mb-2">{request.description}</p>
 
             {/* Attachments */}
             {request.attachments && request.attachments.length > 0 && (
               <div className="mb-3">
                 <div className="flex items-center gap-1 mb-2">
-                  <Paperclip className="h-4 w-4 text-gray-400" />
-                  <span className="text-sm text-gray-600">
+                  <Paperclip className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">
                     Attachments ({request.attachments.length})
                   </span>
                 </div>
@@ -252,10 +256,10 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                   {request.attachments.map((attachment) => (
                     <div
                       key={attachment.name}
-                      className="flex items-center gap-2 bg-gray-50 rounded px-2 py-1"
+                      className="flex items-center gap-2 bg-muted rounded px-2 py-1"
                     >
-                      <span className="text-xs text-gray-700">{attachment.name}</span>
-                      <span className="text-xs text-gray-500">({attachment.size})</span>
+                      <span className="text-xs text-foreground">{attachment.name}</span>
+                      <span className="text-xs text-muted-foreground">({attachment.size})</span>
                       <Button
                         size="sm"
                         variant="ghost"
@@ -271,7 +275,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
               </div>
             )}
 
-            <div className="flex items-center gap-4 text-sm text-gray-500">
+            <div className="flex items-center gap-4 text-sm text-muted-foreground">
               <span>Type: {requestTypeLabel}</span>
               <span>Submitted: {new Date(request.submittedDate).toLocaleDateString()}</span>
             </div>
@@ -282,16 +286,16 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
               request.status === 'reviewed' ||
               request.status === 'commented') &&
               request.reviewComment && (
-                <div className="mt-3 p-3 bg-gray-50 rounded-lg">
+                <div className="mt-3 p-3 bg-muted rounded-lg">
                   <div className="flex items-center gap-2 mb-2">
-                    <span className="text-sm font-medium text-gray-700">Review:</span>
+                    <span className="text-sm font-medium text-foreground">Review:</span>
                     <Badge className={getStatusBadgeColor(request.status)}>
                       {getStatusLabel(request.status)}
                     </Badge>
                   </div>
-                  <p className="text-sm text-gray-600">{request.reviewComment}</p>
+                  <p className="text-sm text-muted-foreground">{request.reviewComment}</p>
                   {request.reviewDate && (
-                    <p className="text-xs text-gray-500 mt-1">
+                    <p className="text-xs text-muted-foreground mt-1">
                       Reviewed on {new Date(request.reviewDate).toLocaleDateString()}
                     </p>
                   )}
@@ -409,15 +413,15 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                     {request.reviewComment && (
                       <div>
                         <Label>Review Comment</Label>
-                        <div className="mt-2 p-3 bg-gray-50 rounded-lg">
-                          <p className="text-sm text-gray-600">{request.reviewComment}</p>
+                        <div className="mt-2 p-3 bg-muted rounded-lg">
+                          <p className="text-sm text-muted-foreground">{request.reviewComment}</p>
                         </div>
                       </div>
                     )}
                     {request.reviewDate && (
                       <div>
                         <Label>Review Date</Label>
-                        <p className="text-sm text-gray-600 mt-1">
+                        <p className="text-sm text-muted-foreground mt-1">
                           {new Date(request.reviewDate).toLocaleDateString()}
                         </p>
                       </div>

--- a/apps/staff/components/reset-password-page.tsx
+++ b/apps/staff/components/reset-password-page.tsx
@@ -87,7 +87,7 @@ export function ResetPasswordPage() {
 
   if (success) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background flex items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
             <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -112,7 +112,7 @@ export function ResetPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="w-16 h-16 bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 rounded-lg flex items-center justify-center mx-auto mb-4">
@@ -135,7 +135,7 @@ export function ResetPasswordPage() {
             <div className="space-y-2">
               <Label htmlFor="password">New Password</Label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                 <Input
                   id="password"
                   type={showPassword ? 'text' : 'password'}
@@ -155,9 +155,9 @@ export function ResetPasswordPage() {
                   onClick={() => setShowPassword(!showPassword)}
                 >
                   {showPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-400" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-400" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
@@ -166,7 +166,7 @@ export function ResetPasswordPage() {
             <div className="space-y-2">
               <Label htmlFor="confirmPassword">Confirm New Password</Label>
               <div className="relative">
-                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                <Lock className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
                 <Input
                   id="confirmPassword"
                   type={showConfirmPassword ? 'text' : 'password'}
@@ -186,25 +186,29 @@ export function ResetPasswordPage() {
                   onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                 >
                   {showConfirmPassword ? (
-                    <EyeOff className="h-4 w-4 text-gray-400" />
+                    <EyeOff className="h-4 w-4 text-muted-foreground" />
                   ) : (
-                    <Eye className="h-4 w-4 text-gray-400" />
+                    <Eye className="h-4 w-4 text-muted-foreground" />
                   )}
                 </Button>
               </div>
             </div>
 
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
-              <p className="text-xs text-blue-800">
+            <div className="bg-muted border border-border rounded-lg p-3">
+              <p className="text-xs text-muted-foreground">
                 <strong>Password Requirements:</strong>
               </p>
-              <ul className="text-xs text-blue-700 mt-1 space-y-1">
-                <li className={password.length >= 8 ? 'text-green-700' : ''}>
+              <ul className="text-xs text-muted-foreground mt-1 space-y-1">
+                <li
+                  className={password.length >= 8 ? 'text-emerald-600 dark:text-emerald-400' : ''}
+                >
                   • At least 8 characters long
                 </li>
                 <li
                   className={
-                    password === confirmPassword && password.length > 0 ? 'text-green-700' : ''
+                    password === confirmPassword && password.length > 0
+                      ? 'text-emerald-600 dark:text-emerald-400'
+                      : ''
                   }
                 >
                   • Passwords must match

--- a/apps/staff/components/scholar-management-table.tsx
+++ b/apps/staff/components/scholar-management-table.tsx
@@ -141,15 +141,15 @@ export function ScholarManagementTable({
   const getStatusColor = (status: string) => {
     switch (status.toLowerCase()) {
       case 'active':
-        return 'bg-green-100 text-green-800';
+        return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
       case 'inactive':
-        return 'bg-gray-100 text-gray-800';
+        return 'bg-muted text-foreground';
       case 'on_hold':
         return 'bg-yellow-100 text-yellow-800';
       case 'archived':
-        return 'bg-gray-200 text-gray-700';
+        return 'bg-muted text-foreground';
       default:
-        return 'bg-gray-100 text-gray-800';
+        return 'bg-muted text-foreground';
     }
   };
 
@@ -226,7 +226,7 @@ export function ScholarManagementTable({
       {/* Search Bar */}
       <div className="flex items-center gap-4">
         <div className="relative flex-1 max-w-sm">
-          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
           <Input
             placeholder="Search students..."
             value={searchTerm}
@@ -353,7 +353,7 @@ export function ScholarManagementTable({
       </div>
 
       {/* Students Table */}
-      <div className="border border-ashinaga-teal-100 rounded-lg">
+      <div className="border border-border rounded-lg">
         <Table>
           <TableHeader>
             <TableRow>
@@ -383,7 +383,7 @@ export function ScholarManagementTable({
               <TableRow>
                 <TableCell colSpan={9} className="text-center py-8">
                   <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2" />
-                  <div className="text-sm text-gray-500">Loading scholars...</div>
+                  <div className="text-sm text-muted-foreground">Loading scholars...</div>
                 </TableCell>
               </TableRow>
             ) : error ? (
@@ -397,7 +397,7 @@ export function ScholarManagementTable({
               </TableRow>
             ) : scholars.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={9} className="text-center py-8 text-gray-500">
+                <TableCell colSpan={9} className="text-center py-8 text-muted-foreground">
                   No scholars found
                 </TableCell>
               </TableRow>
@@ -405,7 +405,7 @@ export function ScholarManagementTable({
               scholars.map((scholar) => (
                 <TableRow
                   key={scholar.id}
-                  className="hover:bg-ashinaga-teal-50 cursor-pointer"
+                  className="hover:bg-muted cursor-pointer"
                   onClick={() => onViewProfile(scholar.id)}
                 >
                   <TableCell onClick={(e) => e.stopPropagation()}>
@@ -429,7 +429,7 @@ export function ScholarManagementTable({
                       </Avatar>
                       <div>
                         <div className="font-medium">{scholar.name}</div>
-                        <div className="text-sm text-gray-500">{scholar.email}</div>
+                        <div className="text-sm text-muted-foreground">{scholar.email}</div>
                       </div>
                     </div>
                   </TableCell>
@@ -440,7 +440,7 @@ export function ScholarManagementTable({
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">
-                      <div className="w-16 bg-gray-200 rounded-full h-2">
+                      <div className="w-16 bg-muted rounded-full h-2">
                         <div
                           className="bg-ashinaga-teal-600 h-2 rounded-full"
                           style={{
@@ -448,7 +448,7 @@ export function ScholarManagementTable({
                           }}
                         />
                       </div>
-                      <span className="text-sm text-gray-600">
+                      <span className="text-sm text-muted-foreground">
                         {scholar.goals.completed}/{scholar.goals.total}
                       </span>
                     </div>
@@ -456,7 +456,7 @@ export function ScholarManagementTable({
                   <TableCell>
                     <Badge className={getStatusColor(scholar.status)}>{scholar.status}</Badge>
                   </TableCell>
-                  <TableCell className="text-sm text-gray-500">
+                  <TableCell className="text-sm text-muted-foreground">
                     {formatDate(scholar.lastActivity)}
                   </TableCell>
                   <TableCell className="text-right">
@@ -525,17 +525,17 @@ export function ScholarManagementTable({
       </div>
 
       {pagination && pagination.totalItems > 0 && (
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm text-gray-600">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between text-sm text-muted-foreground">
           <p>
             Showing{' '}
-            <span className="font-medium text-gray-900">
+            <span className="font-medium text-foreground">
               {(pagination.page - 1) * pagination.limit + 1}
             </span>
             –
-            <span className="font-medium text-gray-900">
+            <span className="font-medium text-foreground">
               {Math.min(pagination.page * pagination.limit, pagination.totalItems)}
             </span>{' '}
-            of <span className="font-medium text-gray-900">{pagination.totalItems}</span> scholars
+            of <span className="font-medium text-foreground">{pagination.totalItems}</span> scholars
             {pagination.totalPages > 1 && (
               <>
                 {' '}

--- a/apps/staff/components/scholar-onboarding.tsx
+++ b/apps/staff/components/scholar-onboarding.tsx
@@ -408,8 +408,10 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
           <CardContent className="pt-6">
             <div className="text-center space-y-4">
               <CheckCircle className="h-16 w-16 text-green-600 mx-auto" />
-              <h2 className="text-2xl font-bold text-gray-900">Scholars Successfully Onboarded!</h2>
-              <p className="text-gray-600">
+              <h2 className="text-2xl font-bold text-foreground">
+                Scholars Successfully Onboarded!
+              </h2>
+              <p className="text-muted-foreground">
                 {activeTab === 'single'
                   ? `${scholarData.name} has been added to the system and invitation sent.`
                   : `${csvData.length} scholars have been added to the system and invitations sent.`}
@@ -443,9 +445,9 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="bg-blue-50 p-4 rounded-lg">
-              <h4 className="font-medium text-blue-900 mb-2">Invitation Preview</h4>
-              <p className="text-sm text-blue-800">
+            <div className="bg-muted p-4 rounded-lg">
+              <h4 className="font-medium text-foreground mb-2">Invitation Preview</h4>
+              <p className="text-sm text-muted-foreground">
                 Scholars will receive an email with login credentials and instructions to access the
                 Ashinaga platform. They'll be able to set up their profile and start tracking their
                 goals.
@@ -857,10 +859,10 @@ export function ScholarOnboarding({ onBack }: ScholarOnboardingProps) {
 
             <TabsContent value="bulk" className="space-y-6">
               <div className="space-y-4">
-                <div className="border-2 border-dashed border-ashinaga-teal-200 rounded-lg p-8 text-center">
+                <div className="border-2 border-dashed border-border rounded-lg p-8 text-center">
                   <FileSpreadsheet className="h-12 w-12 text-ashinaga-teal-400 mx-auto mb-4" />
                   <h3 className="text-lg font-medium mb-2">Upload CSV File</h3>
-                  <p className="text-gray-600 mb-4">
+                  <p className="text-muted-foreground mb-4">
                     Upload a CSV file with student information. Make sure it includes: name, email,
                     program, university, year.
                   </p>

--- a/apps/staff/components/scholar-profile.tsx
+++ b/apps/staff/components/scholar-profile.tsx
@@ -87,13 +87,13 @@ export function ScholarProfilePage({
   const getStatusColor = (status: string) => {
     switch (status) {
       case 'completed':
-        return 'text-green-600';
+        return 'text-green-600 dark:text-green-400';
       case 'in-progress':
-        return 'text-blue-600';
+        return 'text-blue-600 dark:text-blue-400';
       case 'pending':
         return 'text-orange-600';
       default:
-        return 'text-gray-600';
+        return 'text-muted-foreground';
     }
   };
 
@@ -521,44 +521,44 @@ export function ScholarProfilePage({
                 <Badge
                   className={
                     scholar.status === 'archived'
-                      ? 'bg-gray-200 text-gray-800'
+                      ? 'bg-muted text-foreground'
                       : scholar.status === 'active'
-                        ? 'bg-green-100 text-green-800'
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
                         : 'bg-amber-100 text-amber-800'
                   }
                 >
                   {scholar.status}
                 </Badge>
               </div>
-              <p className="text-gray-600 mb-4">{scholar.bio || 'No bio available'}</p>
+              <p className="text-muted-foreground mb-4">{scholar.bio || 'No bio available'}</p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                 <div className="flex items-center gap-2">
-                  <Mail className="h-4 w-4 text-gray-400" />
+                  <Mail className="h-4 w-4 text-muted-foreground" />
                   <span>{scholar.email}</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Phone className="h-4 w-4 text-gray-400" />
+                  <Phone className="h-4 w-4 text-muted-foreground" />
                   <span>{scholar.phone || 'No phone number'}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <MapPin
-                    className="h-4 w-4 text-gray-400 shrink-0"
+                    className="h-4 w-4 text-muted-foreground shrink-0"
                     aria-label="Country of study"
                   />
                   <span>{normalizeLocation(scholar.location ?? '') || 'No location'}</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Calendar className="h-4 w-4 text-gray-400" />
+                  <Calendar className="h-4 w-4 text-muted-foreground" />
                   <span>Started {new Date(scholar.startDate).toLocaleDateString()}</span>
                 </div>
               </div>
             </div>
             <div className="text-right">
-              <p className="text-sm text-gray-500">Program</p>
+              <p className="text-sm text-muted-foreground">Program</p>
               <p className="font-medium">{scholar.program}</p>
-              <p className="text-sm text-gray-500 mt-2">Year</p>
+              <p className="text-sm text-muted-foreground mt-2">Year</p>
               <Badge variant="outline">{scholar.year}</Badge>
-              <p className="text-sm text-gray-500 mt-2">University</p>
+              <p className="text-sm text-muted-foreground mt-2">University</p>
               <p className="font-medium text-sm">{scholar.university}</p>
             </div>
           </div>
@@ -737,7 +737,7 @@ export function ScholarProfilePage({
             {scholar.goals.length === 0 ? (
               <Card>
                 <CardContent className="pt-4">
-                  <p className="text-gray-500 text-center py-4">No LDF goals set yet</p>
+                  <p className="text-muted-foreground text-center py-4">No LDF goals set yet</p>
                 </CardContent>
               </Card>
             ) : (
@@ -750,7 +750,7 @@ export function ScholarProfilePage({
                           <span className="text-2xl">{getCategoryIcon(goal.category)}</span>
                           <div>
                             <h4 className="font-semibold text-lg">{goal.title}</h4>
-                            <div className="flex items-center gap-4 text-sm text-gray-600">
+                            <div className="flex items-center gap-4 text-sm text-muted-foreground">
                               <span>{getCategoryLabel(goal.category)}</span>
                               <span>•</span>
                               <span className="flex items-center gap-1">
@@ -763,36 +763,38 @@ export function ScholarProfilePage({
 
                         {/* Related Skills */}
                         {goal.relatedSkills && (
-                          <div className="mt-3 p-3 bg-blue-50 rounded-lg">
-                            <p className="text-xs font-semibold text-blue-900 mb-1">
+                          <div className="mt-3 p-3 bg-muted rounded-lg">
+                            <p className="text-xs font-semibold text-foreground mb-1">
                               Related LDF Skills & Qualities
                             </p>
-                            <p className="text-sm text-blue-800">{goal.relatedSkills}</p>
+                            <p className="text-sm text-muted-foreground">{goal.relatedSkills}</p>
                           </div>
                         )}
 
                         {/* Action Plan */}
                         {goal.actionPlan && (
-                          <div className="mt-3 p-3 bg-green-50 rounded-lg">
-                            <p className="text-xs font-semibold text-green-900 mb-1">Action Plan</p>
-                            <p className="text-sm text-green-800">{goal.actionPlan}</p>
+                          <div className="mt-3 p-3 bg-muted rounded-lg">
+                            <p className="text-xs font-semibold text-foreground mb-1">
+                              Action Plan
+                            </p>
+                            <p className="text-sm text-muted-foreground">{goal.actionPlan}</p>
                           </div>
                         )}
 
                         {/* Review Notes */}
                         {goal.reviewNotes && (
-                          <div className="mt-3 p-3 bg-purple-50 rounded-lg">
-                            <p className="text-xs font-semibold text-purple-900 mb-1">
+                          <div className="mt-3 p-3 bg-muted rounded-lg">
+                            <p className="text-xs font-semibold text-foreground mb-1">
                               Goal Review & Self-Reflection
                             </p>
-                            <p className="text-sm text-purple-800">{goal.reviewNotes}</p>
+                            <p className="text-sm text-muted-foreground">{goal.reviewNotes}</p>
                           </div>
                         )}
 
                         {/* Completion Scale */}
                         <div className="mt-4">
                           <div className="flex items-center justify-between mb-1">
-                            <span className="text-sm text-gray-600">Completion Scale</span>
+                            <span className="text-sm text-muted-foreground">Completion Scale</span>
                             <span className="text-sm font-medium">{goal.completionScale}/10</span>
                           </div>
                           <Progress value={(goal.completionScale / 10) * 100} className="h-2" />
@@ -848,7 +850,7 @@ export function ScholarProfilePage({
             {scholar.tasks.length === 0 ? (
               <Card>
                 <CardContent className="pt-4">
-                  <p className="text-gray-500 text-center py-4">No tasks assigned yet</p>
+                  <p className="text-muted-foreground text-center py-4">No tasks assigned yet</p>
                 </CardContent>
               </Card>
             ) : (
@@ -861,10 +863,10 @@ export function ScholarProfilePage({
                           <h4 className="font-medium">{task.title}</h4>
                           <Badge variant={getPriorityColor(task.priority)}>{task.priority}</Badge>
                         </div>
-                        <p className="text-sm text-gray-600 mb-2">
+                        <p className="text-sm text-muted-foreground mb-2">
                           {task.description || 'No description'}
                         </p>
-                        <div className="flex items-center gap-4 text-sm text-gray-500">
+                        <div className="flex items-center gap-4 text-sm text-muted-foreground">
                           <span>Due: {new Date(task.dueDate).toLocaleDateString()}</span>
                           <span className={getStatusColor(task.status)}>
                             Status: {task.status.replace('_', ' ')}
@@ -876,7 +878,7 @@ export function ScholarProfilePage({
                             {task.response.responseText && (
                               <div className="mb-2">
                                 <span className="text-sm font-medium">Response: </span>
-                                <span className="text-sm text-gray-600">
+                                <span className="text-sm text-muted-foreground">
                                   {task.response.responseText}
                                 </span>
                               </div>
@@ -889,7 +891,7 @@ export function ScholarProfilePage({
                                     <Badge
                                       key={attachment.id}
                                       variant="secondary"
-                                      className="cursor-pointer hover:bg-gray-200"
+                                      className="cursor-pointer hover:bg-muted"
                                       onClick={async () => {
                                         try {
                                           // Use the attachment ID to get the download URL
@@ -948,7 +950,9 @@ export function ScholarProfilePage({
             {scholar.documents.length === 0 ? (
               <Card>
                 <CardContent className="pt-4">
-                  <p className="text-gray-500 text-center py-4">No documents uploaded yet</p>
+                  <p className="text-muted-foreground text-center py-4">
+                    No documents uploaded yet
+                  </p>
                 </CardContent>
               </Card>
             ) : (
@@ -957,10 +961,10 @@ export function ScholarProfilePage({
                   <CardContent className="pt-4">
                     <div className="flex items-center justify-between">
                       <div className="flex items-center gap-3">
-                        <FileText className="h-8 w-8 text-gray-400" />
+                        <FileText className="h-8 w-8 text-muted-foreground" />
                         <div>
                           <h4 className="font-medium">{doc.name}</h4>
-                          <p className="text-sm text-gray-500">
+                          <p className="text-sm text-muted-foreground">
                             Uploaded {new Date(doc.uploadDate).toLocaleDateString()} • {doc.type}
                           </p>
                         </div>

--- a/apps/staff/components/signup-page.tsx
+++ b/apps/staff/components/signup-page.tsx
@@ -89,7 +89,7 @@ export function SignupPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-ashinaga-teal-50 to-ashinaga-green-50 dark:from-background dark:to-background flex items-center justify-center p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
           <CardTitle className="text-2xl font-bold text-center">Create Account</CardTitle>

--- a/apps/staff/components/task-assignment.tsx
+++ b/apps/staff/components/task-assignment.tsx
@@ -252,7 +252,7 @@ export function TaskAssignment({
 
           {/* Selected Student Display */}
           {selectedScholar && (
-            <div className="bg-ashinaga-teal-50 p-4 rounded-lg">
+            <div className="bg-muted p-4 rounded-lg">
               <div className="flex items-center gap-3">
                 <Avatar>
                   <AvatarImage src={selectedScholar.image || '/placeholder.svg'} />
@@ -265,7 +265,7 @@ export function TaskAssignment({
                 </Avatar>
                 <div>
                   <h4 className="font-medium">{selectedScholar.name}</h4>
-                  <p className="text-sm text-gray-600">
+                  <p className="text-sm text-muted-foreground">
                     {selectedScholar.program} • {selectedScholar.year}
                   </p>
                 </div>

--- a/apps/staff/components/theme-toggle.tsx
+++ b/apps/staff/components/theme-toggle.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Button } from '@workspace/ui';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button variant="ghost" size="sm" className="justify-start text-muted-foreground">
+        <Sun className="mr-2 h-4 w-4" />
+        Light Mode
+      </Button>
+    );
+  }
+
+  const isDark = theme === 'dark';
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="justify-start text-muted-foreground hover:text-foreground"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+    >
+      {isDark ? (
+        <>
+          <Sun className="mr-2 h-4 w-4" />
+          Light Mode
+        </>
+      ) : (
+        <>
+          <Moon className="mr-2 h-4 w-4" />
+          Dark Mode
+        </>
+      )}
+    </Button>
+  );
+}

--- a/apps/staff/components/ui/tabs.tsx
+++ b/apps/staff/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-white border p-1 text-muted-foreground',
+      'inline-flex h-10 items-center justify-center rounded-md bg-white dark:bg-card border p-1 text-muted-foreground',
       className
     )}
     {...props}

--- a/apps/staff/tailwind.config.ts
+++ b/apps/staff/tailwind.config.ts
@@ -81,6 +81,16 @@ const config: Config = {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',
         },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar-background))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))',
+        },
       },
       borderRadius: {
         lg: 'var(--radius)',


### PR DESCRIPTION
## Summary

- Added dark/light theme support to the Staff Portal after noticing it did not have a theme toggle like the Scholar Portal.
- Wired the Staff Portal into `next-themes` and added a visible theme toggle in the staff header.
- Adopted a similar blue-black dark-mode palette to the Scholar Portal, including teal/green accent styling.
- Updated staff dashboard, tabs, request cards, attachments, and review UI so text and surfaces remain readable in dark mode.

## Validation Notes

- `corepack pnpm --filter staff typecheck`: passed
- `corepack pnpm --filter staff test`: passed
- `corepack pnpm --filter staff build`: compiled successfully, then failed on an existing unrelated Next page-data issue for `/_not-found`