### PR TITLE
feat: scholar reply to commented requests, task-assignment emails, active staff management

### DIFF
--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -389,6 +389,236 @@ The Ashinaga Team
     }
   }
 
+  async sendTaskAssignmentNotification(
+    email: string,
+    scholarName: string,
+    taskTitle: string,
+    taskDescription: string | null,
+    taskType: string,
+    taskPriority: 'high' | 'medium' | 'low',
+    dueDate: Date,
+    assignerName: string | null
+  ): Promise<void> {
+    const fromEmail = process.env.EMAIL_FROM || 'noreply@ashinaga.org';
+    const scholarAppUrl = process.env.SCHOLAR_APP_URL || 'http://localhost:4002';
+    const tasksUrl = `${scholarAppUrl}/`;
+    const formattedType = taskType
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+    const formattedDueDate = dueDate.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    const priorityColor =
+      taskPriority === 'high' ? '#DC2626' : taskPriority === 'medium' ? '#F59E0B' : '#0D9488';
+
+    if (!this.resend) {
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log('TASK ASSIGNMENT EMAIL (Resend not configured)');
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log(`To: ${email}`);
+      console.log(`From: ${fromEmail}`);
+      console.log(`Scholar: ${scholarName}`);
+      console.log(`Task: ${taskTitle}`);
+      console.log(`Type: ${formattedType}`);
+      console.log(`Priority: ${taskPriority}`);
+      console.log(`Due: ${formattedDueDate}`);
+      console.log(`Assigned by: ${assignerName ?? 'Ashinaga staff'}`);
+      console.log('═══════════════════════════════════════════════════════════════');
+      return;
+    }
+
+    try {
+      const { data, error } = await this.resend.emails.send({
+        from: fromEmail,
+        to: email,
+        subject: `New task: ${taskTitle}`,
+        html: `
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>New Task Assigned</title>
+            </head>
+            <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+              <div style="background: linear-gradient(135deg, #0D9488 0%, #16A34A 100%); padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+                <h1 style="color: white; margin: 0; font-size: 28px;">Ashinaga</h1>
+              </div>
+
+              <div style="background: white; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 10px 10px;">
+                <h2 style="color: #333; margin-top: 0;">A new task has been assigned to you</h2>
+
+                <p>Dear ${scholarName},</p>
+
+                <p>${assignerName ? `${assignerName} has assigned` : 'Ashinaga staff have assigned'} you a new task in the scholar portal:</p>
+
+                <div style="background: #f8f9fa; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #0D9488;">
+                  <h3 style="margin-top: 0; color: #0D9488;">${taskTitle}</h3>
+                  ${taskDescription ? `<p style="white-space: pre-wrap; margin: 0 0 12px 0;">${taskDescription}</p>` : ''}
+                  <p style="margin: 0; font-size: 14px;"><strong>Type:</strong> ${formattedType}</p>
+                  <p style="margin: 4px 0 0 0; font-size: 14px;"><strong>Priority:</strong> <span style="color: ${priorityColor}; font-weight: 600;">${taskPriority.charAt(0).toUpperCase() + taskPriority.slice(1)}</span></p>
+                  <p style="margin: 4px 0 0 0; font-size: 14px;"><strong>Due:</strong> ${formattedDueDate}</p>
+                </div>
+
+                <div style="text-align: center; margin: 30px 0;">
+                  <a href="${tasksUrl}" style="display: inline-block; background: linear-gradient(135deg, #0D9488 0%, #16A34A 100%); color: white; text-decoration: none; padding: 12px 30px; border-radius: 5px; font-weight: 600;">Open in Portal</a>
+                </div>
+
+                <p style="color: #666; font-size: 14px;">You can view and complete this task in your scholar portal.</p>
+
+                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 30px 0;">
+
+                <p style="color: #666; font-size: 14px;">
+                  Best regards,<br>
+                  The Ashinaga Team
+                </p>
+              </div>
+
+              <div style="text-align: center; padding: 20px; color: #999; font-size: 12px;">
+                <p>© ${new Date().getFullYear()} Ashinaga. All rights reserved.</p>
+              </div>
+            </body>
+          </html>
+        `,
+        text: `
+Dear ${scholarName},
+
+${assignerName ? `${assignerName} has assigned` : 'Ashinaga staff have assigned'} you a new task:
+
+${taskTitle}
+${taskDescription ? `\n${taskDescription}\n` : ''}
+Type: ${formattedType}
+Priority: ${taskPriority}
+Due: ${formattedDueDate}
+
+Open it in your scholar portal:
+${tasksUrl}
+
+Best regards,
+The Ashinaga Team
+        `.trim(),
+      });
+
+      if (error) {
+        console.error('Failed to send task assignment email:', error);
+        throw new Error('Failed to send task assignment email');
+      }
+
+      console.log('Task assignment email sent successfully:', data);
+    } catch (error) {
+      console.error('Error sending task assignment email:', error);
+      throw error;
+    }
+  }
+
+  async sendRequestResponseNotification(
+    email: string,
+    staffName: string,
+    scholarName: string,
+    requestType: string,
+    responseComment: string
+  ): Promise<void> {
+    const fromEmail = process.env.EMAIL_FROM || 'noreply@ashinaga.org';
+    const staffAppUrl = process.env.STAFF_APP_URL || 'http://localhost:4001';
+    const requestsUrl = `${staffAppUrl}/?tab=requests`;
+    const formattedType = requestType
+      .split('_')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+
+    if (!this.resend) {
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log('REQUEST RESPONSE EMAIL (Resend not configured)');
+      console.log('═══════════════════════════════════════════════════════════════');
+      console.log(`To: ${email}`);
+      console.log(`From: ${fromEmail}`);
+      console.log(`Staff: ${staffName}`);
+      console.log(`Scholar: ${scholarName}`);
+      console.log(`Request type: ${formattedType}`);
+      console.log(`Response: ${responseComment}`);
+      console.log('═══════════════════════════════════════════════════════════════');
+      return;
+    }
+
+    try {
+      const { data, error } = await this.resend.emails.send({
+        from: fromEmail,
+        to: email,
+        subject: `${scholarName} replied to a ${formattedType} request`,
+        html: `
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8">
+              <meta name="viewport" content="width=device-width, initial-scale=1.0">
+              <title>Scholar Replied</title>
+            </head>
+            <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+              <div style="background: linear-gradient(135deg, #0D9488 0%, #16A34A 100%); padding: 30px; border-radius: 10px 10px 0 0; text-align: center;">
+                <h1 style="color: white; margin: 0; font-size: 28px;">Ashinaga</h1>
+              </div>
+
+              <div style="background: white; padding: 30px; border: 1px solid #e5e5e5; border-top: none; border-radius: 0 0 10px 10px;">
+                <h2 style="color: #333; margin-top: 0;">Scholar replied with additional information</h2>
+
+                <p>Hi ${staffName},</p>
+
+                <p><strong>${scholarName}</strong> has responded to the comments on their <strong>${formattedType}</strong> request and re-submitted it for review.</p>
+
+                <div style="background: #f0f9ff; padding: 20px; border-radius: 8px; margin: 20px 0; border-left: 4px solid #0D9488;">
+                  <p style="margin: 0; font-weight: 600; color: #666; font-size: 14px;">${scholarName} said:</p>
+                  <p style="white-space: pre-wrap; margin: 10px 0 0 0; font-style: italic;">"${responseComment}"</p>
+                </div>
+
+                <div style="text-align: center; margin: 30px 0;">
+                  <a href="${requestsUrl}" style="display: inline-block; background: linear-gradient(135deg, #0D9488 0%, #16A34A 100%); color: white; text-decoration: none; padding: 12px 30px; border-radius: 5px; font-weight: 600;">Open Requests</a>
+                </div>
+
+                <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 30px 0;">
+
+                <p style="color: #666; font-size: 14px;">
+                  Best regards,<br>
+                  The Ashinaga Team
+                </p>
+              </div>
+
+              <div style="text-align: center; padding: 20px; color: #999; font-size: 12px;">
+                <p>© ${new Date().getFullYear()} Ashinaga. All rights reserved.</p>
+              </div>
+            </body>
+          </html>
+        `,
+        text: `
+Hi ${staffName},
+
+${scholarName} has responded to the comments on their ${formattedType} request and re-submitted it for review.
+
+${scholarName} said:
+"${responseComment}"
+
+Open requests in the staff portal:
+${requestsUrl}
+
+Best regards,
+The Ashinaga Team
+        `.trim(),
+      });
+
+      if (error) {
+        console.error('Failed to send request response notification email:', error);
+        throw new Error('Failed to send request response notification email');
+      }
+
+      console.log('Request response email sent successfully:', data);
+    } catch (error) {
+      console.error('Error sending request response notification email:', error);
+      throw error;
+    }
+  }
+
   async sendRequestStatusNotification(
     email: string,
     scholarName: string,

--- a/apps/api/src/requests/dto/respond-to-request.dto.ts
+++ b/apps/api/src/requests/dto/respond-to-request.dto.ts
@@ -1,0 +1,19 @@
+import { ArrayMaxSize, IsArray, IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
+
+export class RespondToRequestDto {
+  @IsString()
+  @MinLength(1, { message: 'Add a short note about the additional information you are providing.' })
+  comment: string;
+
+  @IsArray()
+  @IsUUID('4', { each: true })
+  @ArrayMaxSize(20)
+  @IsOptional()
+  attachmentIds?: string[];
+}
+
+export class RespondToRequestResponseDto {
+  id: string;
+  status: string;
+  updatedAt: Date;
+}

--- a/apps/api/src/requests/requests.controller.ts
+++ b/apps/api/src/requests/requests.controller.ts
@@ -15,6 +15,7 @@ import type { Request } from 'express';
 import { AuthGuard } from '../auth/auth.guard';
 import { CreateRequestDto, CreateRequestResponseDto } from './dto/create-request.dto';
 import { GetRequestsQueryDto, GetRequestsResponseDto } from './dto/get-requests.dto';
+import { RespondToRequestDto } from './dto/respond-to-request.dto';
 import { RequestsService } from './requests.service';
 
 interface AuthenticatedRequest extends Request {
@@ -94,6 +95,25 @@ export class RequestsController {
       throw new Error('User not authenticated');
     }
     return this.requestsService.createRequest(createRequestDto, userId);
+  }
+
+  @Post(':id/respond')
+  @UseGuards(AuthGuard)
+  async respondToRequest(
+    @Param('id') requestId: string,
+    @Body(new ValidationPipe({ transform: true, whitelist: true })) body: RespondToRequestDto,
+    @Req() req: AuthenticatedRequest
+  ) {
+    const userId = req.user?.id;
+    if (!userId) {
+      throw new Error('User not authenticated');
+    }
+    return this.requestsService.respondToCommentedRequest(
+      requestId,
+      userId,
+      body.comment,
+      body.attachmentIds ?? []
+    );
   }
 
   @Delete(':id')

--- a/apps/api/src/requests/requests.service.ts
+++ b/apps/api/src/requests/requests.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { and, count, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
 import { database } from '../db/connection';
 import {
@@ -485,6 +490,119 @@ export class RequestsService {
         console.error('Failed to send email notification:', error);
         // Don't throw error here - we don't want email failures to break the request update
       }
+    }
+
+    return updatedRequest;
+  }
+
+  async respondToCommentedRequest(
+    requestId: string,
+    userId: string,
+    comment: string,
+    attachmentIds: string[] = []
+  ) {
+    // Find the scholar profile for this user
+    const [scholar] = await database
+      .select()
+      .from(scholars)
+      .where(eq(scholars.userId, userId))
+      .limit(1);
+
+    if (!scholar) {
+      throw new NotFoundException('Scholar not found for this user');
+    }
+
+    // Load the request together with the scholar's user record (for emails)
+    const [requestRow] = await database
+      .select({
+        request: requests,
+        user: users,
+      })
+      .from(requests)
+      .innerJoin(scholars, eq(requests.scholarId, scholars.id))
+      .innerJoin(users, eq(scholars.userId, users.id))
+      .where(eq(requests.id, requestId))
+      .limit(1);
+
+    if (!requestRow) {
+      throw new NotFoundException(`Request with ID ${requestId} not found`);
+    }
+
+    if (requestRow.request.scholarId !== scholar.id) {
+      throw new ForbiddenException('You can only respond to your own requests');
+    }
+
+    if (requestRow.request.archived) {
+      throw new BadRequestException('Cannot respond to an archived request');
+    }
+
+    if (requestRow.request.status !== 'commented') {
+      throw new BadRequestException(
+        'You can only respond when staff have requested additional information'
+      );
+    }
+
+    const previousStatus = requestRow.request.status;
+
+    // Re-open the request so it returns to the staff queue
+    const [updatedRequest] = await database
+      .update(requests)
+      .set({
+        status: 'pending',
+        updatedAt: new Date(),
+      })
+      .where(eq(requests.id, requestId))
+      .returning();
+
+    // Link new attachments to this request (if any)
+    if (attachmentIds.length > 0) {
+      await database
+        .update(requestAttachments)
+        .set({ requestId })
+        .where(inArray(requestAttachments.id, attachmentIds));
+
+      await database.insert(requestAuditLogs).values({
+        requestId,
+        action: 'attachment_added',
+        performedBy: userId,
+        comment: `${attachmentIds.length} file(s) attached with response`,
+        metadata: JSON.stringify({ attachmentIds }),
+      });
+    }
+
+    // Audit log for the response itself
+    await database.insert(requestAuditLogs).values({
+      requestId,
+      action: 'scholar_responded',
+      performedBy: userId,
+      previousStatus,
+      newStatus: 'pending',
+      comment,
+    });
+
+    // Notify the staff members assigned to this request
+    try {
+      const assigneeRows = await database
+        .select({ name: users.name, email: users.email })
+        .from(requestAssignees)
+        .innerJoin(users, eq(users.id, requestAssignees.userId))
+        .where(eq(requestAssignees.requestId, requestId));
+
+      const formattedType = requestRow.request.type.replace(/_/g, ' ');
+      await Promise.allSettled(
+        assigneeRows.map((assignee) =>
+          this.emailService.sendRequestResponseNotification(
+            assignee.email,
+            assignee.name,
+            requestRow.user.name,
+            formattedType,
+            comment
+          )
+        )
+      );
+    } catch (error) {
+      console.error('Failed to notify staff about scholar response:', error);
+      // Don't break the response flow on email failures
     }
 
     return updatedRequest;

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
+import { EmailService } from '../email/email.service';
 import { TasksController } from './tasks.controller';
 import { TasksService } from './tasks.service';
 
 @Module({
   controllers: [TasksController],
-  providers: [TasksService, AuthGuard],
+  providers: [TasksService, AuthGuard, EmailService],
   exports: [TasksService],
 })
 export class TasksModule {}

--- a/apps/api/src/tasks/tasks.service.ts
+++ b/apps/api/src/tasks/tasks.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { and, desc, eq, ilike, isNull, sql } from 'drizzle-orm';
+import { and, desc, eq, ilike, inArray, isNull, sql } from 'drizzle-orm';
 import { getDatabase } from '../db/connection';
 import { scholars } from '../db/schema/scholars';
 import { taskAttachments, taskResponses } from '../db/schema/task-responses';
 import { tasks } from '../db/schema/tasks';
 import { users } from '../db/schema/users';
+import { EmailService } from '../email/email.service';
 import { AttachmentDto, CompleteTaskDto } from './dto/complete-task.dto';
 import { CreateBulkTasksDto } from './dto/create-bulk-tasks.dto';
 import { CreateTaskDto } from './dto/create-task.dto';
@@ -13,6 +14,59 @@ import { UpdateTaskDto } from './dto/update-task.dto';
 @Injectable()
 export class TasksService {
   private db = getDatabase();
+
+  constructor(private readonly emailService: EmailService) {}
+
+  private async notifyScholarsOfAssignment(
+    scholarIds: string[],
+    assignedBy: string,
+    taskInfo: {
+      title: string;
+      description: string | null;
+      type: string;
+      priority: 'high' | 'medium' | 'low';
+      dueDate: Date;
+    }
+  ): Promise<void> {
+    if (scholarIds.length === 0) return;
+
+    const recipients = await this.db
+      .select({
+        scholarId: scholars.id,
+        email: users.email,
+        name: users.name,
+      })
+      .from(scholars)
+      .innerJoin(users, eq(scholars.userId, users.id))
+      .where(inArray(scholars.id, scholarIds));
+
+    const [assigner] = await this.db
+      .select({ name: users.name })
+      .from(users)
+      .where(eq(users.id, assignedBy))
+      .limit(1);
+
+    const assignerName = assigner?.name ?? null;
+
+    await Promise.allSettled(
+      recipients.map((recipient) =>
+        this.emailService
+          .sendTaskAssignmentNotification(
+            recipient.email,
+            recipient.name,
+            taskInfo.title,
+            taskInfo.description,
+            taskInfo.type,
+            taskInfo.priority,
+            taskInfo.dueDate,
+            assignerName
+          )
+          .catch((error) => {
+            console.error(`Failed to send task assignment email to ${recipient.email}:`, error);
+          })
+      )
+    );
+  }
 
   async createTask(createTaskDto: CreateTaskDto, assignedBy: string) {
     const [task] = await this.db
@@ -28,6 +82,14 @@ export class TasksService {
         status: 'pending',
       })
       .returning();
+
+    void this.notifyScholarsOfAssignment([task.scholarId], assignedBy, {
+      title: task.title,
+      description: task.description,
+      type: task.type,
+      priority: task.priority,
+      dueDate: task.dueDate,
+    });
 
     return task;
   }
@@ -47,6 +109,15 @@ export class TasksService {
     }));
 
     const inserted = await this.db.insert(tasks).values(rows).returning();
+
+    void this.notifyScholarsOfAssignment(uniqueScholarIds, assignedBy, {
+      title: dto.title,
+      description: dto.description ?? null,
+      type: dto.type,
+      priority: dto.priority || 'medium',
+      dueDate,
+    });
+
     return { created: inserted.length, tasks: inserted };
   }
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,6 +1,7 @@
-import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Req, UseGuards } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from '../auth/auth.guard';
+import { StaffGuard } from '../auth/staff.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { UsersService } from './users.service';
 
@@ -37,10 +38,36 @@ export class UsersController {
 
   @Get('staff')
   @UseGuards(AuthGuard)
-  @ApiOperation({ summary: 'Get list of active staff members' })
-  @ApiResponse({ status: 200, description: 'Returns list of active staff' })
+  @ApiOperation({ summary: 'Get list of active staff members (minimal)' })
+  @ApiResponse({ status: 200, description: 'Returns list of active staff (id, name, email)' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getStaffList() {
-    return this.usersService.getStaffList();
+    const list = await this.usersService.getStaffList();
+    return list.map(({ userId, name, email }) => ({ id: userId, name, email }));
+  }
+
+  @Get('staff/manage')
+  @UseGuards(StaffGuard)
+  @ApiOperation({ summary: 'Get detailed list of active staff for management' })
+  @ApiResponse({ status: 200, description: 'Returns detailed staff list and caller permissions' })
+  async getStaffForManagement(@Req() req: any) {
+    const userId = req.user?.id;
+    if (!userId) {
+      throw new Error('User not authenticated');
+    }
+    return this.usersService.getStaffManagementView(userId);
+  }
+
+  @Delete('staff/:userId')
+  @UseGuards(StaffGuard)
+  @ApiOperation({ summary: 'Remove (deactivate) a staff member. Super-admin only.' })
+  @ApiResponse({ status: 200, description: 'Staff member removed' })
+  @ApiResponse({ status: 403, description: 'Forbidden – super-admin required' })
+  async removeStaffMember(@Param('userId') targetUserId: string, @Req() req: any) {
+    const requesterUserId = req.user?.id;
+    if (!requesterUserId) {
+      throw new Error('User not authenticated');
+    }
+    return this.usersService.removeStaff(targetUserId, requesterUserId);
   }
 }

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
+import { StaffGuard } from '../auth/staff.guard';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService, AuthGuard],
+  providers: [UsersService, AuthGuard, StaffGuard],
 })
 export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,8 +1,24 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { database } from '../db/connection';
-import { staff, users } from '../db/schema';
+import { sessions, staff, users } from '../db/schema';
 import { UpdateUserDto } from './dto/update-user.dto';
+
+export interface StaffListItem {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'viewer';
+  isSuperAdmin: boolean;
+  joinedAt: Date;
+  isSelf: boolean;
+}
 
 @Injectable()
 export class UsersService {
@@ -60,18 +76,87 @@ export class UsersService {
     return this.findById(userId);
   }
 
-  async getStaffList(): Promise<{ id: string; name: string; email: string }[]> {
-    // Get all active staff members with their user info
+  async getStaffList(currentUserId?: string): Promise<StaffListItem[]> {
+    // Active staff with full details for management views
     const staffList = await database
       .select({
-        id: users.id,
+        id: staff.id,
+        userId: users.id,
         name: users.name,
         email: users.email,
+        role: staff.role,
+        isSuperAdmin: staff.isSuperAdmin,
+        joinedAt: staff.createdAt,
       })
       .from(staff)
       .innerJoin(users, eq(staff.userId, users.id))
       .where(eq(staff.isActive, true));
 
-    return staffList;
+    return staffList.map((row) => ({
+      ...row,
+      isSelf: currentUserId ? row.userId === currentUserId : false,
+    }));
+  }
+
+  async getStaffManagementView(
+    currentUserId: string
+  ): Promise<{ staff: StaffListItem[]; canManage: boolean }> {
+    const list = await this.getStaffList(currentUserId);
+    const me = list.find((row) => row.userId === currentUserId);
+    return {
+      staff: list,
+      canManage: Boolean(me?.isSuperAdmin),
+    };
+  }
+
+  async removeStaff(targetUserId: string, requesterUserId: string) {
+    if (targetUserId === requesterUserId) {
+      throw new BadRequestException('You cannot remove your own staff account');
+    }
+
+    // Verify requester is an active super-admin
+    const [requester] = await database
+      .select()
+      .from(staff)
+      .where(eq(staff.userId, requesterUserId))
+      .limit(1);
+
+    if (!requester || !requester.isActive) {
+      throw new ForbiddenException('Staff access required');
+    }
+
+    if (!requester.isSuperAdmin) {
+      throw new ForbiddenException('Only super-admins can remove staff members');
+    }
+
+    // Find the target staff record
+    const [target] = await database
+      .select()
+      .from(staff)
+      .where(eq(staff.userId, targetUserId))
+      .limit(1);
+
+    if (!target) {
+      throw new NotFoundException('Staff member not found');
+    }
+
+    if (!target.isActive) {
+      return { success: true, alreadyInactive: true };
+    }
+
+    // Soft-delete: mark inactive
+    await database
+      .update(staff)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(eq(staff.userId, targetUserId));
+
+    // Invalidate any active sessions so the removed staff can't keep using the app
+    try {
+      await database.delete(sessions).where(eq(sessions.userId, targetUserId));
+    } catch (error) {
+      console.error('Failed to clear sessions for removed staff member:', error);
+    }
+
+    return { success: true, alreadyInactive: false };
   }
 }

--- a/apps/api/test/integration/invitations.integration.spec.ts
+++ b/apps/api/test/integration/invitations.integration.spec.ts
@@ -14,8 +14,8 @@ import {
   deleteInvitationByEmail,
   getTestPool,
   randomEmail,
-  seedStaffUser,
   type SeededStaff,
+  seedStaffUser,
 } from './helpers/seed';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;

--- a/apps/api/test/integration/requests.integration.spec.ts
+++ b/apps/api/test/integration/requests.integration.spec.ts
@@ -14,10 +14,10 @@ import { type AuthContext, createAuthenticatedIntegrationApp } from './helpers/c
 import {
   cleanupSeeded,
   getTestPool,
-  seedScholarUser,
-  seedStaffUser,
   type SeededScholar,
   type SeededStaff,
+  seedScholarUser,
+  seedStaffUser,
 } from './helpers/seed';
 
 describe('Requests API – multi-assignee (integration)', () => {

--- a/apps/api/test/integration/tasks.integration.spec.ts
+++ b/apps/api/test/integration/tasks.integration.spec.ts
@@ -14,10 +14,10 @@ import { type AuthContext, createAuthenticatedIntegrationApp } from './helpers/c
 import {
   cleanupSeeded,
   getTestPool,
-  seedScholarUser,
-  seedStaffUser,
   type SeededScholar,
   type SeededStaff,
+  seedScholarUser,
+  seedStaffUser,
 } from './helpers/seed';
 
 describe('Tasks API – bulk/soft-delete/suggestions (integration)', () => {

--- a/apps/scholar/components/request-card.tsx
+++ b/apps/scholar/components/request-card.tsx
@@ -1,11 +1,18 @@
 'use client';
 
-import { Calendar, ChevronDown, ChevronUp, Download, Paperclip } from 'lucide-react';
-import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Calendar, ChevronDown, ChevronUp, Download, Loader2, Paperclip, X } from 'lucide-react';
+import { useRef, useState } from 'react';
 import type { Request } from '../lib/api-client';
+import { respondToRequest } from '../lib/api-client';
+import { useFileUpload } from '../lib/hooks/use-file-upload';
+import { queryKeys } from '../lib/hooks/use-queries';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Progress } from './ui/progress';
+import { Textarea } from './ui/textarea';
+import { useToast } from './ui/use-toast';
 
 interface RequestCardProps {
   request: Request;
@@ -13,6 +20,14 @@ interface RequestCardProps {
 
 export function RequestCard({ request }: RequestCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showRespondForm, setShowRespondForm] = useState(false);
+  const [responseComment, setResponseComment] = useState('');
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { uploadFiles, uploadProgress, isUploading } = useFileUpload();
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {
@@ -96,6 +111,60 @@ export function RequestCard({ request }: RequestCardProps) {
         </div>
       </div>
     );
+  };
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    setSelectedFiles((prev) => [...prev, ...files]);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  };
+
+  const handleRemoveFile = (index: number) => {
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmitResponse = async () => {
+    const trimmed = responseComment.trim();
+    if (!trimmed) {
+      toast({
+        title: 'Add a note',
+        description: 'Tell staff what additional information you are providing.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      let attachmentIds: string[] = [];
+      if (selectedFiles.length > 0) {
+        const uploaded = await uploadFiles(selectedFiles, request.id);
+        attachmentIds = uploaded.map((f) => f.attachmentId);
+      }
+
+      await respondToRequest(request.id, {
+        comment: trimmed,
+        attachmentIds: attachmentIds.length > 0 ? attachmentIds : undefined,
+      });
+
+      toast({
+        title: 'Response submitted',
+        description: 'Staff will review your additional information shortly.',
+      });
+      setResponseComment('');
+      setSelectedFiles([]);
+      setShowRespondForm(false);
+      await queryClient.invalidateQueries({ queryKey: queryKeys.myRequests });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      toast({
+        title: 'Could not submit response',
+        description: msg.replace(/^API Error:\s*\d+\s*-\s*/, ''),
+        variant: 'destructive',
+      });
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -203,6 +272,136 @@ export function RequestCard({ request }: RequestCardProps) {
                   day: 'numeric',
                 })}
               </p>
+            )}
+          </div>
+        )}
+
+        {/* Respond to commented request */}
+        {request.status === 'commented' && (
+          <div className="rounded-lg border border-blue-500/30 bg-blue-500/5 p-4 space-y-3">
+            {!showRespondForm ? (
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+                <p className="text-sm text-foreground">
+                  Staff have asked for more information. Reply on this same request — no need to
+                  submit a new one.
+                </p>
+                <Button
+                  type="button"
+                  onClick={() => setShowRespondForm(true)}
+                  className="bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700 shrink-0"
+                >
+                  Respond with more info
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <div className="space-y-2">
+                  <label
+                    htmlFor={`respond-${request.id}`}
+                    className="text-sm font-medium text-foreground"
+                  >
+                    Your response
+                  </label>
+                  <Textarea
+                    id={`respond-${request.id}`}
+                    value={responseComment}
+                    onChange={(e) => setResponseComment(e.target.value)}
+                    placeholder="Provide the additional information staff asked for…"
+                    rows={4}
+                    disabled={submitting || isUploading}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium text-foreground">
+                      Add files (optional)
+                    </span>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={submitting || isUploading}
+                    >
+                      <Paperclip className="h-4 w-4 mr-2" />
+                      Choose files
+                    </Button>
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      multiple
+                      className="hidden"
+                      onChange={handleFileSelect}
+                    />
+                  </div>
+                  {selectedFiles.length > 0 && (
+                    <ul className="space-y-1">
+                      {selectedFiles.map((file, idx) => {
+                        const progress = uploadProgress[idx];
+                        return (
+                          <li
+                            key={`${file.name}-${idx}`}
+                            className="flex items-center justify-between bg-muted rounded-md px-3 py-2 text-sm"
+                          >
+                            <div className="flex-1 min-w-0">
+                              <p className="truncate text-foreground">{file.name}</p>
+                              {progress?.status === 'uploading' && (
+                                <Progress value={progress.progress} className="h-1 mt-1" />
+                              )}
+                              {progress?.status === 'error' && (
+                                <p className="text-xs text-destructive mt-0.5">
+                                  {progress.error || 'Upload failed'}
+                                </p>
+                              )}
+                            </div>
+                            {!submitting && !isUploading && (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleRemoveFile(idx)}
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+
+                <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => {
+                      setShowRespondForm(false);
+                      setResponseComment('');
+                      setSelectedFiles([]);
+                    }}
+                    disabled={submitting || isUploading}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    type="button"
+                    onClick={handleSubmitResponse}
+                    disabled={submitting || isUploading}
+                    className="bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700"
+                  >
+                    {submitting || isUploading ? (
+                      <>
+                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        {isUploading ? 'Uploading…' : 'Submitting…'}
+                      </>
+                    ) : (
+                      'Send response'
+                    )}
+                  </Button>
+                </div>
+              </div>
             )}
           </div>
         )}

--- a/apps/scholar/lib/api-client.ts
+++ b/apps/scholar/lib/api-client.ts
@@ -148,6 +148,21 @@ export async function createRequest(data: CreateRequestData): Promise<Request> {
   });
 }
 
+export interface RespondToRequestData {
+  comment: string;
+  attachmentIds?: string[];
+}
+
+export async function respondToRequest(
+  requestId: string,
+  data: RespondToRequestData
+): Promise<{ id: string; status: string; updatedAt: string }> {
+  return fetchAPI(`/api/requests/${requestId}/respond`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
 // Staff types and functions
 export interface StaffMember {
   id: string;

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -609,6 +609,7 @@ function StaffDashboardContent() {
                         <SelectItem value="approved">Approved</SelectItem>
                         <SelectItem value="rejected">Rejected</SelectItem>
                         <SelectItem value="reviewed">Reviewed</SelectItem>
+                        <SelectItem value="commented">Commented</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/apps/staff/components/invitations-management.tsx
+++ b/apps/staff/components/invitations-management.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import { Loader2, Mail, Search, UserPlus } from 'lucide-react';
+import { Loader2, Mail, Search, Shield, Trash2, UserPlus, Users } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   cancelInvitation,
   createStaffInvitation,
   getInvitations,
+  getStaffForManagement,
   type InvitationSummary,
+  removeStaffMember,
   resendInvitation,
+  type StaffMember,
 } from '../lib/api-client';
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
@@ -320,8 +323,187 @@ function InviteStaffButton({ onInvited }: { onInvited: () => void }) {
   );
 }
 
+function ActiveStaffList() {
+  const { toast } = useToast();
+  const [members, setMembers] = useState<StaffMember[]>([]);
+  const [canManage, setCanManage] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [busyUserId, setBusyUserId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await getStaffForManagement();
+      setMembers(res.staff);
+      setCanManage(res.canManage);
+    } catch (e) {
+      toast({
+        title: 'Could not load staff',
+        description: e instanceof Error ? e.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return members;
+    return members.filter(
+      (m) => m.email.toLowerCase().includes(q) || m.name.toLowerCase().includes(q)
+    );
+  }, [members, search]);
+
+  const handleRemove = async (member: StaffMember) => {
+    if (member.isSelf) return;
+    const confirmed = window.confirm(
+      `Remove ${member.name} (${member.email}) from staff?\n\nThey will lose access immediately and their active sessions will be ended. This cannot be undone from the app.`
+    );
+    if (!confirmed) return;
+    setBusyUserId(member.userId);
+    try {
+      await removeStaffMember(member.userId);
+      toast({
+        title: 'Staff member removed',
+        description: `${member.name} no longer has access to the staff portal.`,
+      });
+      await load();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      toast({
+        title: 'Could not remove staff member',
+        description: msg.replace(/^API Error:\s*\d+\s*-\s*/, ''),
+        variant: 'destructive',
+      });
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative w-full sm:max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by name or email…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        {!loading && !canManage && (
+          <p className="text-xs text-muted-foreground">
+            Only super-admins can remove staff members.
+          </p>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="rounded-lg border overflow-hidden">
+          <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
+            <div className="col-span-4">Name</div>
+            <div className="col-span-4">Email</div>
+            <div className="col-span-2">Role</div>
+            <div className="col-span-2 text-right">Actions</div>
+          </div>
+          <div className="divide-y">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="px-4 py-3.5">
+                <Skeleton className="h-4 w-3/4" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-lg border flex flex-col items-center justify-center py-16 text-center">
+          <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-border bg-muted/40">
+            <Users className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <p className="text-sm font-medium text-foreground">No active staff</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {search ? 'Nothing matches your search.' : 'Invite a colleague to get started.'}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
+            <div className="col-span-4">Name</div>
+            <div className="col-span-4">Email</div>
+            <div className="col-span-2">Role</div>
+            <div className="col-span-2 text-right">Actions</div>
+          </div>
+          <ul className="divide-y">
+            {filtered.map((member) => (
+              <li
+                key={member.userId}
+                className="grid grid-cols-12 gap-2 px-4 py-3 items-center text-sm transition-colors hover:bg-muted/30"
+              >
+                <div className="col-span-4 font-medium text-foreground flex items-center gap-2">
+                  <span className="truncate">{member.name}</span>
+                  {member.isSelf && (
+                    <Badge variant="outline" className="text-[10px] font-normal">
+                      You
+                    </Badge>
+                  )}
+                </div>
+                <div className="col-span-4 break-all text-muted-foreground">{member.email}</div>
+                <div className="col-span-2 flex items-center gap-1.5">
+                  <Badge
+                    variant={member.role === 'admin' ? 'success' : 'muted'}
+                    className="capitalize"
+                  >
+                    {member.role}
+                  </Badge>
+                  {member.isSuperAdmin && (
+                    <span title="Super admin" className="text-amber-600">
+                      <Shield className="h-3.5 w-3.5" />
+                    </span>
+                  )}
+                </div>
+                <div className="col-span-2 flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-destructive"
+                    disabled={!canManage || member.isSelf || busyUserId !== null}
+                    onClick={() => handleRemove(member)}
+                    title={
+                      member.isSelf
+                        ? 'You cannot remove yourself'
+                        : !canManage
+                          ? 'Only super-admins can remove staff'
+                          : 'Remove staff member'
+                    }
+                  >
+                    {busyUserId === member.userId ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <>
+                        <Trash2 className="h-3.5 w-3.5 mr-1" />
+                        Remove
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function InvitationsManagement({ onOnboardScholar }: { onOnboardScholar: () => void }) {
-  const [tab, setTab] = useState<'staff' | 'scholar'>('staff');
+  const [tab, setTab] = useState<'staff-members' | 'staff' | 'scholar'>('staff-members');
   const [refreshKey, setRefreshKey] = useState(0);
 
   return (
@@ -329,15 +511,14 @@ export function InvitationsManagement({ onOnboardScholar }: { onOnboardScholar: 
       <CardHeader>
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <CardTitle>Invitations</CardTitle>
+            <CardTitle>Staff & Invitations</CardTitle>
             <CardDescription>
-              Track and manage staff and scholar invitations. Invitations expire after 30 days.
+              Manage active staff, and track staff and scholar invitations. Invitations expire after
+              30 days.
             </CardDescription>
           </div>
           <div className="flex gap-2">
-            {tab === 'staff' ? (
-              <InviteStaffButton onInvited={() => setRefreshKey((k) => k + 1)} />
-            ) : (
+            {tab === 'scholar' ? (
               <Button
                 onClick={onOnboardScholar}
                 className="bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700"
@@ -345,6 +526,8 @@ export function InvitationsManagement({ onOnboardScholar }: { onOnboardScholar: 
                 <UserPlus className="mr-2 h-4 w-4" />
                 Onboard Scholar
               </Button>
+            ) : (
+              <InviteStaffButton onInvited={() => setRefreshKey((k) => k + 1)} />
             )}
           </div>
         </div>
@@ -352,13 +535,17 @@ export function InvitationsManagement({ onOnboardScholar }: { onOnboardScholar: 
       <CardContent>
         <Tabs
           value={tab}
-          onValueChange={(v) => setTab(v as 'staff' | 'scholar')}
+          onValueChange={(v) => setTab(v as 'staff-members' | 'staff' | 'scholar')}
           className="space-y-4"
         >
-          <TabsList className="grid w-full grid-cols-2 sm:w-[320px]">
-            <TabsTrigger value="staff">Staff</TabsTrigger>
-            <TabsTrigger value="scholar">Scholar</TabsTrigger>
+          <TabsList className="grid w-full grid-cols-3 sm:w-[480px]">
+            <TabsTrigger value="staff-members">Active Staff</TabsTrigger>
+            <TabsTrigger value="staff">Staff Invites</TabsTrigger>
+            <TabsTrigger value="scholar">Scholar Invites</TabsTrigger>
           </TabsList>
+          <TabsContent value="staff-members">
+            <ActiveStaffList key={`staff-members-${refreshKey}`} />
+          </TabsContent>
           <TabsContent value="staff">
             <InvitationList key={`staff-${refreshKey}`} userType="staff" />
           </TabsContent>

--- a/apps/staff/lib/api-client.ts
+++ b/apps/staff/lib/api-client.ts
@@ -822,3 +822,32 @@ export async function cancelInvitation(invitationId: string): Promise<{ message:
     method: 'DELETE',
   });
 }
+
+// Staff management
+export interface StaffMember {
+  id: string;
+  userId: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'viewer';
+  isSuperAdmin: boolean;
+  joinedAt: string;
+  isSelf: boolean;
+}
+
+export interface StaffManagementResponse {
+  staff: StaffMember[];
+  canManage: boolean;
+}
+
+export async function getStaffForManagement(): Promise<StaffManagementResponse> {
+  return fetchAPI<StaffManagementResponse>('/api/users/staff/manage');
+}
+
+export async function removeStaffMember(
+  userId: string
+): Promise<{ success: boolean; alreadyInactive: boolean }> {
+  return fetchAPI<{ success: boolean; alreadyInactive: boolean }>(`/api/users/staff/${userId}`, {
+    method: 'DELETE',
+  });
+}

--- a/apps/staff/test/e2e/staff-features.e2e-spec.ts
+++ b/apps/staff/test/e2e/staff-features.e2e-spec.ts
@@ -16,23 +16,26 @@ test.describe('Staff Portal – new features', () => {
     await expect(page.getByRole('heading', { name: /Ashinaga Staff/ })).toBeVisible();
   });
 
-  test('Invitations tab is visible and renders Staff/Scholar sub-tabs', async ({ page }) => {
+  test('Invitations tab is visible and renders Active Staff / Staff Invites / Scholar Invites sub-tabs', async ({
+    page,
+  }) => {
     const invitationsTab = page.getByRole('tab', { name: /Invitations/i });
     await expect(invitationsTab).toBeVisible();
     await invitationsTab.click();
 
-    // Sub-tabs visible
-    await expect(page.getByRole('tab', { name: 'Staff', exact: true })).toBeVisible();
-    await expect(page.getByRole('tab', { name: 'Scholar', exact: true })).toBeVisible();
+    // Sub-tabs visible (renamed when the Active Staff management view was added)
+    await expect(page.getByRole('tab', { name: 'Active Staff', exact: true })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Staff Invites', exact: true })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Scholar Invites', exact: true })).toBeVisible();
 
     // The card header mentions the new 30-day expiry
     await expect(page.getByText(/expire after 30 days/i)).toBeVisible();
 
-    // Invite Staff button on the Staff sub-tab
+    // Invite Staff button is the default action on Active Staff / Staff Invites tabs
     await expect(page.getByRole('button', { name: /Invite Staff/i })).toBeVisible();
 
-    // Switching to Scholar shows the Onboard Scholar button instead
-    await page.getByRole('tab', { name: 'Scholar', exact: true }).click();
+    // Switching to Scholar Invites shows the Onboard Scholar button instead
+    await page.getByRole('tab', { name: 'Scholar Invites', exact: true }).click();
     await expect(page.getByRole('button', { name: /Onboard Scholar/i })).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary
Addresses Odinaka's three pieces of feedback:

- **Reply to a commented request on the same application** — scholars can now respond inline with a note + attachments instead of submitting a brand-new request. The request flips back to `pending` so it re-enters the staff queue, and the assignees get emailed.
- **Email notification when a task is assigned** — `TasksService.createTask` / `createBulkTasks` now fire a Resend email to the scholar (single + bulk). Previously this event was silent.
- **Remove staff from the app** — new **Active Staff** sub-tab under Invitations. Super-admins can deactivate a staff member; their sessions are killed immediately and `staff.is_active` is set to false. This is how Silvia (and future leavers) get removed.

Also added the **Commented** option to the staff request status filter so re-submitted requests are easy to find.

## New API surface
- `POST /api/requests/:id/respond` — scholar comment + attachments on the same request (auth-guarded, ownership-checked, requires `status='commented'`)
- `GET /api/users/staff/manage` — detailed active staff list + `canManage` flag (staff-guarded)
- `DELETE /api/users/staff/:userId` — soft-delete a staff member (staff-guarded, super-admin enforced server-side, clears the removed user's sessions)

Existing `GET /api/users/staff` is unchanged (still returns minimal `{id,name,email}` for the scholar assignee selector).

## Notes
- Email failures are swallowed (don't break task creation or request response). Resend fallback still console-logs when `RESEND_API_KEY` is unset, matching the existing pattern.
- Removing staff requires `staff.is_super_admin = true` on the caller — server enforces this even if the client tries to bypass. If no super-admin exists yet, set the flag in SQL / via `db:bootstrap-prod` first.
- Real web/mobile push notifications are intentionally **not** in this PR — email already satisfies the asked-for scenarios (task assigned, request reviewed, announcement). Real push is a larger lift (service worker + VAPID + subscriptions) worth its own PR.

## Test plan
- [ ] Scholar portal: submit a request, have a staff user mark it `commented` with a note, log back in as the scholar and use **Respond with more info** to send a reply + a file. Confirm status flips to `pending`, attachment appears on the same card, assignees receive the response email.
- [ ] Staff portal: assign a task to a scholar (single + bulk). Confirm the scholar receives the task-assignment email with title, type, priority, due date, and assigner name.
- [ ] Staff portal → Invitations → **Active Staff**: as a super-admin, remove a non-self staff row. Confirm they're logged out on next request and no longer appear in the list. Confirm self-row Remove is disabled and non-super-admin sees Remove disabled.
- [ ] Filter the staff Requests view by **Commented** and confirm re-submitted (now `pending`) and originally-commented entries are findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)