### PR TITLE
Ash 64 staff app navigation mobile responsiveness

### DIFF
--- a/apps/staff/app/globals.css
+++ b/apps/staff/app/globals.css
@@ -99,7 +99,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground antialiased;
+    @apply overflow-x-hidden bg-background text-foreground antialiased;
     font-feature-settings:
       "rlig" 1,
       "calt" 1,

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -4,6 +4,7 @@ import {
   AlertCircle,
   FileText,
   Loader2,
+  LogOut,
   Mail,
   MessageSquare,
   Trash2,
@@ -58,20 +59,30 @@ type StaffDashboardView =
   | 'task-assignment'
   | 'my-profile';
 
+const STAFF_NAV_ITEMS = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'scholars', label: 'Scholars' },
+  { value: 'requests', label: 'Requests' },
+  { value: 'announcements', label: 'Announcements' },
+  { value: 'invitations', label: 'Invitations' },
+];
+
 interface QuickActionButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   icon: React.ReactNode;
   label: string;
+  description?: string;
   primary?: boolean;
 }
 
 const QuickActionButton = forwardRef<HTMLButtonElement, QuickActionButtonProps>(
-  ({ icon, label, primary, className, ...props }, ref) => (
+  ({ icon, label, description, primary, className, ...props }, ref) => (
     <button
       ref={ref}
       type="button"
       className={cn(
-        'group relative flex items-center gap-3 bg-card px-5 py-4 text-sm transition-colors',
+        'group relative flex min-w-0 items-center gap-3 bg-card px-4 py-4 text-left text-sm transition-colors sm:px-5',
         'hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:z-10',
+        'lg:flex-col lg:items-start lg:justify-between lg:rounded-lg lg:border lg:border-border lg:p-4 lg:hover:border-foreground/20',
         className
       )}
       {...props}
@@ -84,7 +95,14 @@ const QuickActionButton = forwardRef<HTMLButtonElement, QuickActionButtonProps>(
       >
         {icon}
       </span>
-      <span className="font-medium text-foreground">{label}</span>
+      <span className="min-w-0">
+        <span className="block font-medium text-foreground">{label}</span>
+        {description && (
+          <span className="mt-1 hidden text-xs leading-5 text-muted-foreground lg:block">
+            {description}
+          </span>
+        )}
+      </span>
     </button>
   )
 );
@@ -336,6 +354,10 @@ function StaffDashboardContent() {
     router.push('?tab=requests');
   };
 
+  const handleTabChange = (tab: string) => {
+    router.push(tab === 'overview' ? '/' : `?tab=${tab}`);
+  };
+
   const handleSignOut = async () => {
     await signOut();
     router.push('/');
@@ -365,20 +387,29 @@ function StaffDashboardContent() {
     <div className="min-h-screen bg-background">
       {/* Header — sticky, glassy, sleek */}
       <header className="sticky top-0 z-40 w-full border-b border-border bg-background/80 backdrop-blur-xl">
-        <div className="flex h-14 items-center justify-between max-w-7xl mx-auto px-6">
-          <div className="flex items-center gap-3">
-            <div className="h-8 w-8 rounded-md bg-brand flex items-center justify-center">
+        <div className="mx-auto flex h-14 max-w-7xl items-center justify-between gap-2 px-3 sm:gap-3 sm:px-6">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-brand">
               <span className="text-brand-foreground font-semibold text-sm">A</span>
             </div>
-            <div className="flex flex-col leading-tight">
-              <h1 className="text-sm font-medium text-foreground">Ashinaga Staff</h1>
-              <p className="text-[11px] text-muted-foreground">Supporting Scholar Success</p>
+            <div className="flex min-w-0 flex-col leading-tight">
+              <h1 className="truncate text-sm font-medium text-foreground">Ashinaga Staff</h1>
+              <p className="hidden truncate text-[11px] text-muted-foreground sm:block">
+                Supporting Scholar Success
+              </p>
             </div>
           </div>
-          <div className="flex items-center gap-1">
+          <div className="flex shrink-0 items-center gap-1">
             <ThemeToggle />
-            <Button variant="ghost" size="sm" onClick={handleSignOut}>
-              Logout
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 w-8 px-0 sm:w-auto sm:px-3"
+              onClick={handleSignOut}
+              aria-label="Logout"
+            >
+              <LogOut className="h-4 w-4 sm:hidden" />
+              <span className="hidden sm:inline">Logout</span>
             </Button>
             <button
               type="button"
@@ -386,7 +417,7 @@ function StaffDashboardContent() {
               onClick={() => router.push('?view=my-profile')}
               aria-label="Open my profile"
             >
-              <Avatar className="h-8 w-8 cursor-pointer">
+              <Avatar className="h-8 w-8 cursor-pointer max-[380px]:hidden">
                 {user?.image && <AvatarImage src={user.image} alt={user.name || 'User'} />}
                 <AvatarFallback className="text-xs">
                   {user?.name
@@ -401,19 +432,15 @@ function StaffDashboardContent() {
         </div>
       </header>
 
-      <div className="max-w-7xl mx-auto px-6 py-8 animate-fade-in">
+      <div className="mx-auto max-w-7xl px-3 py-5 animate-fade-in sm:px-6 sm:py-8">
         {currentView === 'onboarding' ? (
           <ScholarOnboarding onBack={() => router.push('/')} />
         ) : currentView === 'my-profile' ? (
           <MyProfile onBack={() => router.push('/')} />
         ) : (
-          <Tabs
-            value={activeTab}
-            onValueChange={(tab) => router.push(tab === 'overview' ? '/' : `?tab=${tab}`)}
-            className="space-y-6"
-          >
-            <div className="flex items-center justify-between">
-              <div>
+          <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+              <div className="min-w-0">
                 <h2 className="text-2xl font-semibold tracking-tight text-foreground">
                   {activeTab === 'overview' && 'Overview'}
                   {activeTab === 'scholars' && 'Scholars'}
@@ -429,8 +456,22 @@ function StaffDashboardContent() {
                   {activeTab === 'invitations' && 'Invite scholars and staff to the portal.'}
                 </p>
               </div>
+              <div className="sm:hidden">
+                <Select value={activeTab} onValueChange={handleTabChange}>
+                  <SelectTrigger aria-label="Section" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STAFF_NAV_ITEMS.map((item) => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
-            <TabsList className="inline-flex">
+            <TabsList className="hidden h-auto flex-wrap sm:inline-flex">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="scholars">Scholars</TabsTrigger>
               <TabsTrigger value="requests">Requests</TabsTrigger>
@@ -443,14 +484,14 @@ function StaffDashboardContent() {
 
             <TabsContent value="overview" className="space-y-6">
               {/* Stats Overview — flatter, tabular numerals, brand chip rather than gradient tile */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-3 sm:gap-4 md:grid-cols-2">
                 <button
                   type="button"
                   onClick={navigateToScholars}
-                  className="group text-left rounded-lg border bg-card p-5 transition-colors hover:border-foreground/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  className="group text-left rounded-lg border bg-card p-4 transition-colors hover:border-foreground/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:p-5"
                 >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="space-y-1">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 space-y-1">
                       <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                         Total Scholars
                       </p>
@@ -466,7 +507,7 @@ function StaffDashboardContent() {
                         {scholarStats?.active || 0} active
                       </p>
                     </div>
-                    <div className="h-9 w-9 rounded-md border border-border bg-muted/40 flex items-center justify-center transition-colors group-hover:bg-muted">
+                    <div className="hidden h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40 transition-colors group-hover:bg-muted min-[430px]:flex sm:h-9 sm:w-9">
                       <Users className="h-4 w-4 text-muted-foreground" />
                     </div>
                   </div>
@@ -475,10 +516,10 @@ function StaffDashboardContent() {
                 <button
                   type="button"
                   onClick={navigateToRequests}
-                  className="group text-left rounded-lg border bg-card p-5 transition-colors hover:border-foreground/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  className="group text-left rounded-lg border bg-card p-4 transition-colors hover:border-foreground/20 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring sm:p-5"
                 >
-                  <div className="flex items-start justify-between gap-4">
-                    <div className="space-y-1">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 space-y-1">
                       <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
                         Pending Requests
                       </p>
@@ -493,7 +534,7 @@ function StaffDashboardContent() {
                         of {requestStats?.total || 0} total
                       </p>
                     </div>
-                    <div className="h-9 w-9 rounded-md border border-border bg-muted/40 flex items-center justify-center transition-colors group-hover:bg-muted">
+                    <div className="hidden h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-muted/40 transition-colors group-hover:bg-muted min-[430px]:flex sm:h-9 sm:w-9">
                       <AlertCircle className="h-4 w-4 text-muted-foreground" />
                     </div>
                   </div>
@@ -502,7 +543,7 @@ function StaffDashboardContent() {
 
               {/* Quick Actions */}
               <div className="rounded-lg border bg-card">
-                <div className="flex items-center justify-between p-5 pb-3">
+                <div className="flex items-center justify-between p-4 pb-3 sm:p-5 sm:pb-3">
                   <div className="space-y-0.5">
                     <h3 className="text-sm font-semibold leading-none tracking-tight">
                       Quick actions
@@ -512,10 +553,11 @@ function StaffDashboardContent() {
                     </p>
                   </div>
                 </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-px bg-border border-t">
+                <div className="grid grid-cols-1 gap-px border-t bg-border min-[520px]:grid-cols-2 lg:grid-cols-5 lg:gap-3 lg:border-t-0 lg:bg-transparent lg:p-5 lg:pt-2">
                   <QuickActionButton
                     icon={<Users className="h-4 w-4" />}
                     label="Onboard Scholar"
+                    description="Create a new scholar profile and invitation."
                     onClick={() => router.push('?view=onboarding')}
                     primary
                   />
@@ -524,6 +566,7 @@ function StaffDashboardContent() {
                       <QuickActionButton
                         icon={<FileText className="h-4 w-4" />}
                         label="Assign Task"
+                        description="Send a task to one or more scholars."
                       />
                     }
                     onSuccess={(scholarId) => {
@@ -535,11 +578,13 @@ function StaffDashboardContent() {
                   <QuickActionButton
                     icon={<MessageSquare className="h-4 w-4" />}
                     label="Create Announcement"
+                    description="Publish an update for filtered scholars."
                     onClick={() => router.push('?tab=announcements')}
                   />
                   <QuickActionButton
                     icon={<FileText className="h-4 w-4" />}
                     label="Review Requests"
+                    description="Triage funding and requirement submissions."
                     onClick={() => router.push('?tab=requests')}
                   />
                   <StaffInviteDialog
@@ -547,6 +592,7 @@ function StaffDashboardContent() {
                       <QuickActionButton
                         icon={<UserPlus className="h-4 w-4" />}
                         label="Invite Staff"
+                        description="Add another staff member to the portal."
                       />
                     }
                   />
@@ -565,7 +611,7 @@ function StaffDashboardContent() {
                 />
               ) : (
                 <Card>
-                  <CardContent className="p-5">
+                  <CardContent className="p-4 sm:p-5">
                     <ScholarManagementTable
                       onViewProfile={(scholarId) => {
                         router.push(`?tab=scholars&view=scholar-profile&scholarId=${scholarId}`);
@@ -614,7 +660,7 @@ function StaffDashboardContent() {
                     </Select>
                   </div>
                 </div>
-                <CardContent className="p-5">
+                <CardContent className="p-4 sm:p-5">
                   {requestsLoading ? (
                     <div className="space-y-3">
                       <Skeleton className="h-24 w-full" />
@@ -663,7 +709,7 @@ function StaffDashboardContent() {
                 <AnnouncementCreator />
               </div>
               <Card>
-                <CardContent className="p-5">
+                <CardContent className="p-4 sm:p-5">
                   <div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                     <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-5">
                       <Select

--- a/apps/staff/components/invitations-management.tsx
+++ b/apps/staff/components/invitations-management.tsx
@@ -153,64 +153,78 @@ function InvitationList({ userType }: InvitationListProps) {
       </div>
 
       {loading ? (
-        <div className="rounded-lg border overflow-hidden">
-          <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
-            <div className="col-span-4">Email</div>
-            <div className="col-span-2">Status</div>
-            <div className="col-span-2">Sent / Resends</div>
-            <div className="col-span-2">Expires</div>
-            <div className="col-span-2 text-right">Actions</div>
-          </div>
-          <div className="divide-y">
+        <div className="space-y-3">
+          <div className="space-y-2 lg:hidden">
             {[0, 1, 2].map((i) => (
-              <div key={i} className="px-4 py-3.5">
+              <div key={i} className="rounded-lg border p-4">
                 <Skeleton className="h-4 w-3/4" />
               </div>
             ))}
           </div>
+          <div className="hidden overflow-hidden rounded-lg border lg:block">
+            <div className="grid grid-cols-12 gap-2 border-b bg-muted/30 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              <div className="col-span-4">Email</div>
+              <div className="col-span-2">Status</div>
+              <div className="col-span-2">Sent / Resends</div>
+              <div className="col-span-2">Expires</div>
+              <div className="col-span-2 text-right">Actions</div>
+            </div>
+            <div className="divide-y">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="px-4 py-3.5">
+                  <Skeleton className="h-4 w-3/4" />
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       ) : filtered.length === 0 ? (
-        <div className="rounded-lg border flex flex-col items-center justify-center py-16 text-center">
+        <div className="flex flex-col items-center justify-center rounded-lg border py-16 text-center">
           <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-border bg-muted/40">
             <Mail className="h-5 w-5 text-muted-foreground" />
           </div>
-          <p className="text-sm font-medium text-foreground">No invitations</p>
-          <p className="mt-1 text-sm text-muted-foreground">Nothing matches the current filters.</p>
+          <p className="font-medium text-foreground text-sm">No invitations</p>
+          <p className="mt-1 text-muted-foreground text-sm">Nothing matches the current filters.</p>
         </div>
       ) : (
-        <div className="rounded-lg border overflow-hidden">
-          <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
-            <div className="col-span-4">Email</div>
-            <div className="col-span-2">Status</div>
-            <div className="col-span-2">Sent / Resends</div>
-            <div className="col-span-2">Expires</div>
-            <div className="col-span-2 text-right">Actions</div>
-          </div>
-          <ul className="divide-y">
+        <>
+          <ul className="space-y-3 lg:hidden">
             {filtered.map((inv) => {
               const expires = new Date(inv.expiresAt);
               const isPending = inv.status === 'pending';
               return (
-                <li
-                  key={inv.id}
-                  className="grid grid-cols-12 gap-2 px-4 py-3 items-center text-sm transition-colors hover:bg-muted/30"
-                >
-                  <div className="col-span-4 break-all font-medium text-foreground">
-                    {inv.email}
-                  </div>
-                  <div className="col-span-2">
-                    <StatusBadge status={inv.status} />
-                  </div>
-                  <div className="col-span-2 text-muted-foreground">
-                    <div className="tabular-nums">
-                      {inv.sentAt ? new Date(inv.sentAt).toLocaleDateString() : '—'}
+                <li key={inv.id} className="rounded-lg border p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="break-all font-medium text-foreground text-sm">{inv.email}</p>
+                      <div className="mt-2">
+                        <StatusBadge status={inv.status} />
+                      </div>
                     </div>
-                    <div className="text-xs tabular-nums">Resends: {inv.resentCount}</div>
                   </div>
-                  <div className="col-span-2 text-muted-foreground tabular-nums">
-                    {expires.toLocaleDateString()}
-                  </div>
-                  <div className="col-span-2 flex justify-end gap-1">
+                  <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <dt className="text-muted-foreground text-xs uppercase tracking-wider">
+                        Sent
+                      </dt>
+                      <dd className="tabular-nums">
+                        {inv.sentAt ? new Date(inv.sentAt).toLocaleDateString() : '—'}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground text-xs uppercase tracking-wider">
+                        Expires
+                      </dt>
+                      <dd className="tabular-nums">{expires.toLocaleDateString()}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground text-xs uppercase tracking-wider">
+                        Resends
+                      </dt>
+                      <dd className="tabular-nums">{inv.resentCount}</dd>
+                    </div>
+                  </dl>
+                  <div className="mt-4 grid grid-cols-2 gap-2">
                     <Button
                       type="button"
                       variant="outline"
@@ -222,7 +236,7 @@ function InvitationList({ userType }: InvitationListProps) {
                     </Button>
                     <Button
                       type="button"
-                      variant="ghost"
+                      variant="outline"
                       size="sm"
                       className="text-muted-foreground hover:text-destructive"
                       disabled={!isPending || busyId !== null}
@@ -235,7 +249,69 @@ function InvitationList({ userType }: InvitationListProps) {
               );
             })}
           </ul>
-        </div>
+          <div className="hidden overflow-hidden rounded-lg border lg:block">
+            <div className="grid grid-cols-12 gap-2 border-b bg-muted/30 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              <div className="col-span-4">Email</div>
+              <div className="col-span-2">Status</div>
+              <div className="col-span-2">Sent / Resends</div>
+              <div className="col-span-2">Expires</div>
+              <div className="col-span-2 text-right">Actions</div>
+            </div>
+            <ul className="divide-y">
+              {filtered.map((inv) => {
+                const expires = new Date(inv.expiresAt);
+                const isPending = inv.status === 'pending';
+                return (
+                  <li
+                    key={inv.id}
+                    className="grid grid-cols-12 items-center gap-2 px-4 py-3 text-sm transition-colors hover:bg-muted/30"
+                  >
+                    <div className="col-span-4 break-all font-medium text-foreground">
+                      {inv.email}
+                    </div>
+                    <div className="col-span-2">
+                      <StatusBadge status={inv.status} />
+                    </div>
+                    <div className="col-span-2 text-muted-foreground">
+                      <div className="tabular-nums">
+                        {inv.sentAt ? new Date(inv.sentAt).toLocaleDateString() : '—'}
+                      </div>
+                      <div className="text-xs tabular-nums">Resends: {inv.resentCount}</div>
+                    </div>
+                    <div className="col-span-2 text-muted-foreground tabular-nums">
+                      {expires.toLocaleDateString()}
+                    </div>
+                    <div className="col-span-2 flex justify-end gap-1">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={!isPending || busyId !== null}
+                        onClick={() => handleResend(inv.id)}
+                      >
+                        {busyId === inv.id ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          'Resend'
+                        )}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-muted-foreground hover:text-destructive"
+                        disabled={!isPending || busyId !== null}
+                        onClick={() => handleCancel(inv.id)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </>
       )}
     </div>
   );
@@ -279,7 +355,7 @@ function InviteStaffButton({ onInvited }: { onInvited: () => void }) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button className="bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700">
+        <Button className="w-full bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700 sm:w-auto">
           <UserPlus className="mr-2 h-4 w-4" />
           Invite Staff
         </Button>
@@ -305,12 +381,12 @@ function InviteStaffButton({ onInvited }: { onInvited: () => void }) {
               disabled={submitting}
             />
           </div>
-          <DialogFooter className="sm:justify-start gap-2">
+          <DialogFooter className="gap-2 sm:justify-start">
             <Button type="submit" disabled={submitting}>
               {submitting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Sending…
+                  Sending...
                 </>
               ) : (
                 'Send invitation'
@@ -322,7 +398,6 @@ function InviteStaffButton({ onInvited }: { onInvited: () => void }) {
     </Dialog>
   );
 }
-
 function ActiveStaffList() {
   const { toast } = useToast();
   const [members, setMembers] = useState<StaffMember[]>([]);
@@ -406,19 +481,28 @@ function ActiveStaffList() {
       </div>
 
       {loading ? (
-        <div className="rounded-lg border overflow-hidden">
-          <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
-            <div className="col-span-4">Name</div>
-            <div className="col-span-4">Email</div>
-            <div className="col-span-2">Role</div>
-            <div className="col-span-2 text-right">Actions</div>
-          </div>
-          <div className="divide-y">
+        <div className="space-y-3">
+          <div className="space-y-2 lg:hidden">
             {[0, 1, 2].map((i) => (
-              <div key={i} className="px-4 py-3.5">
+              <div key={i} className="rounded-lg border p-4">
                 <Skeleton className="h-4 w-3/4" />
               </div>
             ))}
+          </div>
+          <div className="hidden rounded-lg border overflow-hidden lg:block">
+            <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
+              <div className="col-span-4">Name</div>
+              <div className="col-span-4">Email</div>
+              <div className="col-span-2">Role</div>
+              <div className="col-span-2 text-right">Actions</div>
+            </div>
+            <div className="divide-y">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="px-4 py-3.5">
+                  <Skeleton className="h-4 w-3/4" />
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       ) : filtered.length === 0 ? (
@@ -432,45 +516,40 @@ function ActiveStaffList() {
           </p>
         </div>
       ) : (
-        <div className="rounded-lg border overflow-hidden">
-          <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
-            <div className="col-span-4">Name</div>
-            <div className="col-span-4">Email</div>
-            <div className="col-span-2">Role</div>
-            <div className="col-span-2 text-right">Actions</div>
-          </div>
-          <ul className="divide-y">
+        <>
+          <ul className="space-y-3 lg:hidden">
             {filtered.map((member) => (
-              <li
-                key={member.userId}
-                className="grid grid-cols-12 gap-2 px-4 py-3 items-center text-sm transition-colors hover:bg-muted/30"
-              >
-                <div className="col-span-4 font-medium text-foreground flex items-center gap-2">
-                  <span className="truncate">{member.name}</span>
-                  {member.isSelf && (
-                    <Badge variant="outline" className="text-[10px] font-normal">
-                      You
-                    </Badge>
+              <li key={member.userId} className="rounded-lg border p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <p className="max-w-full truncate text-sm font-medium text-foreground">
+                        {member.name}
+                      </p>
+                      {member.isSelf && (
+                        <Badge variant="outline" className="text-[10px] font-normal">
+                          You
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="mt-1 break-all text-sm text-muted-foreground">{member.email}</p>
+                  </div>
+                  {member.isSuperAdmin && (
+                    <span title="Super admin" className="shrink-0 text-amber-600">
+                      <Shield className="h-4 w-4" />
+                    </span>
                   )}
                 </div>
-                <div className="col-span-4 break-all text-muted-foreground">{member.email}</div>
-                <div className="col-span-2 flex items-center gap-1.5">
+                <div className="mt-3 flex items-center justify-between gap-3">
                   <Badge
                     variant={member.role === 'admin' ? 'success' : 'muted'}
                     className="capitalize"
                   >
                     {member.role}
                   </Badge>
-                  {member.isSuperAdmin && (
-                    <span title="Super admin" className="text-amber-600">
-                      <Shield className="h-3.5 w-3.5" />
-                    </span>
-                  )}
-                </div>
-                <div className="col-span-2 flex justify-end">
                   <Button
                     type="button"
-                    variant="ghost"
+                    variant="outline"
                     size="sm"
                     className="text-muted-foreground hover:text-destructive"
                     disabled={!canManage || member.isSelf || busyUserId !== null}
@@ -496,7 +575,72 @@ function ActiveStaffList() {
               </li>
             ))}
           </ul>
-        </div>
+          <div className="hidden rounded-lg border overflow-hidden lg:block">
+            <div className="grid grid-cols-12 gap-2 px-4 py-3 text-[11px] font-medium uppercase tracking-wider text-muted-foreground border-b bg-muted/30">
+              <div className="col-span-4">Name</div>
+              <div className="col-span-4">Email</div>
+              <div className="col-span-2">Role</div>
+              <div className="col-span-2 text-right">Actions</div>
+            </div>
+            <ul className="divide-y">
+              {filtered.map((member) => (
+                <li
+                  key={member.userId}
+                  className="grid grid-cols-12 gap-2 px-4 py-3 items-center text-sm transition-colors hover:bg-muted/30"
+                >
+                  <div className="col-span-4 font-medium text-foreground flex items-center gap-2">
+                    <span className="truncate">{member.name}</span>
+                    {member.isSelf && (
+                      <Badge variant="outline" className="text-[10px] font-normal">
+                        You
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="col-span-4 break-all text-muted-foreground">{member.email}</div>
+                  <div className="col-span-2 flex items-center gap-1.5">
+                    <Badge
+                      variant={member.role === 'admin' ? 'success' : 'muted'}
+                      className="capitalize"
+                    >
+                      {member.role}
+                    </Badge>
+                    {member.isSuperAdmin && (
+                      <span title="Super admin" className="text-amber-600">
+                        <Shield className="h-3.5 w-3.5" />
+                      </span>
+                    )}
+                  </div>
+                  <div className="col-span-2 flex justify-end">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground hover:text-destructive"
+                      disabled={!canManage || member.isSelf || busyUserId !== null}
+                      onClick={() => handleRemove(member)}
+                      title={
+                        member.isSelf
+                          ? 'You cannot remove yourself'
+                          : !canManage
+                            ? 'Only super-admins can remove staff'
+                            : 'Remove staff member'
+                      }
+                    >
+                      {busyUserId === member.userId ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <>
+                          <Trash2 className="h-3.5 w-3.5 mr-1" />
+                          Remove
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </>
       )}
     </div>
   );
@@ -505,23 +649,28 @@ function ActiveStaffList() {
 export function InvitationsManagement({ onOnboardScholar }: { onOnboardScholar: () => void }) {
   const [tab, setTab] = useState<'staff-members' | 'staff' | 'scholar'>('staff-members');
   const [refreshKey, setRefreshKey] = useState(0);
+  const tabLabels = {
+    'staff-members': 'Active Staff',
+    staff: 'Staff Invites',
+    scholar: 'Scholar Invites',
+  };
 
   return (
     <Card className="border-border">
-      <CardHeader>
+      <CardHeader className="p-4 sm:p-6">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <CardTitle>Staff & Invitations</CardTitle>
+          <div className="min-w-0">
+            <CardTitle className="text-xl leading-tight sm:text-2xl">Staff & Invitations</CardTitle>
             <CardDescription>
               Manage active staff, and track staff and scholar invitations. Invitations expire after
               30 days.
             </CardDescription>
           </div>
-          <div className="flex gap-2">
+          <div className="flex w-full gap-2 sm:w-auto sm:shrink-0">
             {tab === 'scholar' ? (
               <Button
                 onClick={onOnboardScholar}
-                className="bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700"
+                className="w-full bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700 sm:w-auto"
               >
                 <UserPlus className="mr-2 h-4 w-4" />
                 Onboard Scholar
@@ -532,13 +681,25 @@ export function InvitationsManagement({ onOnboardScholar }: { onOnboardScholar: 
           </div>
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="p-4 pt-0 sm:p-6 sm:pt-0">
         <Tabs
           value={tab}
           onValueChange={(v) => setTab(v as 'staff-members' | 'staff' | 'scholar')}
           className="space-y-4"
         >
-          <TabsList className="grid w-full grid-cols-3 sm:w-[480px]">
+          <div className="sm:hidden">
+            <Select value={tab} onValueChange={(v) => setTab(v as typeof tab)}>
+              <SelectTrigger aria-label="Invitation section">
+                <SelectValue placeholder={tabLabels[tab]} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="staff-members">Active Staff</SelectItem>
+                <SelectItem value="staff">Staff Invites</SelectItem>
+                <SelectItem value="scholar">Scholar Invites</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <TabsList className="hidden w-full grid-cols-3 sm:grid sm:w-[480px]">
             <TabsTrigger value="staff-members">Active Staff</TabsTrigger>
             <TabsTrigger value="staff">Staff Invites</TabsTrigger>
             <TabsTrigger value="scholar">Scholar Invites</TabsTrigger>

--- a/apps/staff/components/request-management.tsx
+++ b/apps/staff/components/request-management.tsx
@@ -230,18 +230,18 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
   );
 
   return (
-    <Card className="p-4 border border-border rounded-lg">
+    <Card className="rounded-lg border border-border p-4">
       <CardContent className="p-0">
-        <div className="flex items-start justify-between">
-          <div className="flex-1">
-            <div className="flex items-center gap-2 mb-2">
-              <h4 className="font-medium text-foreground">{request.scholarName}</h4>
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1">
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <h4 className="min-w-0 font-medium text-foreground">{request.scholarName}</h4>
               <Badge variant={getPriorityColor(request.priority)}>{request.priority}</Badge>
               <Badge className={getStatusBadgeColor(request.status)}>
                 {getStatusLabel(request.status)}
               </Badge>
             </div>
-            <p className="text-sm text-muted-foreground mb-2">{request.description}</p>
+            <p className="mb-3 text-sm text-muted-foreground">{request.description}</p>
 
             {/* Attachments */}
             {request.attachments && request.attachments.length > 0 && (
@@ -256,10 +256,14 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                   {request.attachments.map((attachment) => (
                     <div
                       key={attachment.name}
-                      className="flex items-center gap-2 bg-muted rounded px-2 py-1"
+                      className="flex max-w-full items-center gap-2 rounded bg-muted px-2 py-1"
                     >
-                      <span className="text-xs text-foreground">{attachment.name}</span>
-                      <span className="text-xs text-muted-foreground">({attachment.size})</span>
+                      <span className="min-w-0 truncate text-xs text-foreground">
+                        {attachment.name}
+                      </span>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        ({attachment.size})
+                      </span>
                       <Button
                         size="sm"
                         variant="ghost"
@@ -275,9 +279,14 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
               </div>
             )}
 
-            <div className="flex items-center gap-4 text-sm text-muted-foreground">
-              <span>Type: {requestTypeLabel}</span>
-              <span>Submitted: {new Date(request.submittedDate).toLocaleDateString()}</span>
+            <div className="grid grid-cols-1 gap-2 text-sm text-muted-foreground sm:grid-cols-2">
+              <span>
+                <span className="text-foreground">Type:</span> {requestTypeLabel}
+              </span>
+              <span>
+                <span className="text-foreground">Submitted:</span>{' '}
+                {new Date(request.submittedDate).toLocaleDateString()}
+              </span>
             </div>
 
             {/* Show review details if already reviewed */}
@@ -303,14 +312,14 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
               )}
           </div>
 
-          <div className="flex gap-2">
+          <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap sm:justify-end lg:shrink-0">
             {/* Show different buttons based on status */}
             {canMakeDecision && (
               <>
                 {/* Approval Dialog */}
                 <Dialog open={approvalOpen} onOpenChange={setApprovalOpen}>
                   <DialogTrigger asChild>
-                    <Button size="sm">
+                    <Button size="sm" className="w-full sm:w-auto">
                       <CheckCircle className="h-4 w-4 mr-1" />
                       Review
                     </Button>
@@ -375,9 +384,15 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
 
             {/* Print Button for approved and rejected requests */}
             {(request.status === 'approved' || request.status === 'rejected') && (
-              <Button size="sm" variant="outline" onClick={handlePrint}>
+              <Button
+                size="sm"
+                variant="outline"
+                className="w-full sm:w-auto"
+                onClick={handlePrint}
+              >
                 <Download className="h-4 w-4 mr-1" />
-                Download Application
+                <span className="sm:hidden">Download</span>
+                <span className="hidden sm:inline">Download Application</span>
               </Button>
             )}
 
@@ -388,7 +403,7 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
               request.status === 'commented') && (
               <Dialog open={viewReviewOpen} onOpenChange={setViewReviewOpen}>
                 <DialogTrigger asChild>
-                  <Button size="sm" variant="outline">
+                  <Button size="sm" variant="outline" className="w-full sm:w-auto">
                     <Eye className="h-4 w-4 mr-1" />
                     View Review
                   </Button>
@@ -439,11 +454,13 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
             {/* Delete Button */}
             <Button
               size="sm"
-              variant="ghost"
-              className="text-red-500 hover:text-red-700 hover:bg-red-50"
+              variant="outline"
+              className="col-span-2 w-full border-red-900/40 text-red-500 hover:bg-red-950/30 hover:text-red-400 sm:col-span-1 sm:w-auto"
               onClick={handleDelete}
+              aria-label={`Delete request from ${request.scholarName}`}
             >
               <Trash2 className="h-4 w-4" />
+              <span className="ml-1">Delete</span>
             </Button>
           </div>
         </div>

--- a/apps/staff/components/scholar-management-table.tsx
+++ b/apps/staff/components/scholar-management-table.tsx
@@ -224,8 +224,8 @@ export function ScholarManagementTable({
   return (
     <div className="space-y-4">
       {/* Search Bar */}
-      <div className="flex items-center gap-4">
-        <div className="relative flex-1 max-w-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="relative w-full lg:max-w-sm">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground h-4 w-4" />
           <Input
             placeholder="Search students..."
@@ -234,12 +234,12 @@ export function ScholarManagementTable({
             className="pl-10"
           />
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
           {selectedScholars.length > 0 && (
             <BulkTaskAssignment
               selectedScholarIds={selectedScholars}
               trigger={
-                <Button variant="outline">
+                <Button variant="outline" className="w-full sm:w-auto">
                   <Plus className="h-4 w-4 mr-2" />
                   Assign Task to Selected ({selectedScholars.length})
                 </Button>
@@ -257,7 +257,12 @@ export function ScholarManagementTable({
             }
           />
           */}
-          <Button variant="outline" onClick={handleExportCsv} disabled={exportingCsv}>
+          <Button
+            variant="outline"
+            className="w-full sm:w-auto"
+            onClick={handleExportCsv}
+            disabled={exportingCsv}
+          >
             {exportingCsv ? (
               <Loader2 className="h-4 w-4 mr-2 animate-spin" />
             ) : (
@@ -266,7 +271,7 @@ export function ScholarManagementTable({
             Export all (CSV)
           </Button>
           <Button
-            className="bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700"
+            className="w-full bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 hover:from-ashinaga-teal-700 hover:to-ashinaga-green-700 sm:w-auto"
             onClick={onOnboardScholar}
           >
             <Plus className="h-4 w-4 mr-2" />
@@ -275,12 +280,12 @@ export function ScholarManagementTable({
         </div>
       </div>
 
-      <div className="flex items-center gap-4 flex-wrap">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4">
         <Select
           value={statusFilter}
           onValueChange={(v) => setStatusFilter(v as typeof statusFilter)}
         >
-          <SelectTrigger className="w-[140px]">
+          <SelectTrigger>
             <SelectValue placeholder="Status" />
           </SelectTrigger>
           <SelectContent>
@@ -292,7 +297,7 @@ export function ScholarManagementTable({
           </SelectContent>
         </Select>
         <Select value={programFilter} onValueChange={setProgramFilter}>
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger>
             <SelectValue placeholder="All Programs" />
           </SelectTrigger>
           <SelectContent>
@@ -306,7 +311,7 @@ export function ScholarManagementTable({
         </Select>
 
         <Select value={yearFilter} onValueChange={setYearFilter}>
-          <SelectTrigger className="w-[140px]">
+          <SelectTrigger>
             <SelectValue placeholder="All Years" />
           </SelectTrigger>
           <SelectContent>
@@ -320,7 +325,7 @@ export function ScholarManagementTable({
         </Select>
 
         <Select value={universityFilter} onValueChange={setUniversityFilter}>
-          <SelectTrigger className="w-[200px]">
+          <SelectTrigger>
             <SelectValue placeholder="All Universities" />
           </SelectTrigger>
           <SelectContent>
@@ -340,6 +345,7 @@ export function ScholarManagementTable({
           <Button
             variant="outline"
             size="sm"
+            className="sm:col-span-2 lg:col-span-4 lg:w-fit"
             onClick={() => {
               setProgramFilter('all');
               setYearFilter('all');
@@ -352,8 +358,148 @@ export function ScholarManagementTable({
         )}
       </div>
 
+      <div className="space-y-3 lg:hidden">
+        {isLoading ? (
+          <div className="rounded-lg border border-border bg-card p-6 text-center">
+            <Loader2 className="mx-auto mb-2 h-6 w-6 animate-spin" />
+            <div className="text-sm text-muted-foreground">Loading scholars...</div>
+          </div>
+        ) : error ? (
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : scholars.length === 0 ? (
+          <div className="rounded-lg border border-border bg-card p-6 text-center text-sm text-muted-foreground">
+            No scholars found
+          </div>
+        ) : (
+          scholars.map((scholar) => (
+            <article key={scholar.id} className="rounded-lg border border-border bg-card p-4">
+              <div className="flex items-start gap-3">
+                <div>
+                  <Checkbox
+                    checked={selectedScholars.includes(scholar.id)}
+                    onCheckedChange={(checked) =>
+                      handleSelectScholar(scholar.id, checked as boolean)
+                    }
+                    aria-label={`Select ${scholar.name}`}
+                  />
+                </div>
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-start gap-3 text-left"
+                  onClick={() => onViewProfile(scholar.id)}
+                >
+                  <Avatar className="h-9 w-9 shrink-0">
+                    <AvatarImage src={scholar.image || '/placeholder.svg'} />
+                    <AvatarFallback>
+                      {scholar.name
+                        .split(' ')
+                        .map((n: string) => n[0])
+                        .join('')}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="min-w-0">
+                    <span className="block truncate font-medium">{scholar.name}</span>
+                    <span className="block truncate text-sm text-muted-foreground">
+                      {scholar.email}
+                    </span>
+                  </span>
+                </button>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" aria-label={`Actions for ${scholar.name}`}>
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => onViewProfile(scholar.id)}>
+                      <Eye className="h-4 w-4 mr-2" />
+                      View Profile
+                    </DropdownMenuItem>
+                    {scholar.status !== 'archived' && (
+                      <DropdownMenuItem
+                        onClick={(e) => {
+                          e.preventDefault();
+                          handleArchive(scholar.id, scholar.name);
+                        }}
+                      >
+                        <Archive className="h-4 w-4 mr-2" />
+                        Archive
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      className="text-red-600 focus:text-red-600"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handleDelete(scholar.id, scholar.name);
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Delete
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+
+              <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div className="min-w-0">
+                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">
+                    Program
+                  </dt>
+                  <dd className="truncate font-medium">{scholar.program}</dd>
+                </div>
+                <div className="min-w-0">
+                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">Year</dt>
+                  <dd>
+                    <Badge variant="outline">{scholar.year}</Badge>
+                  </dd>
+                </div>
+                <div className="min-w-0">
+                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">
+                    University
+                  </dt>
+                  <dd className="truncate font-medium">{scholar.university}</dd>
+                </div>
+                <div className="min-w-0">
+                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">Status</dt>
+                  <dd>
+                    <Badge className={getStatusColor(scholar.status)}>{scholar.status}</Badge>
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">Goals</dt>
+                  <dd className="font-medium">
+                    {scholar.goals.completed}/{scholar.goals.total}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">
+                    Last Activity
+                  </dt>
+                  <dd className="font-medium">{formatDate(scholar.lastActivity)}</dd>
+                </div>
+              </dl>
+
+              <div className="mt-4">
+                <TaskAssignment
+                  trigger={
+                    <Button size="sm" variant="outline" className="w-full">
+                      <Plus className="h-4 w-4 mr-1" />
+                      Assign Task
+                    </Button>
+                  }
+                  preselectedScholarId={scholar.id}
+                />
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+
       {/* Students Table */}
-      <div className="border border-border rounded-lg">
+      <div className="hidden rounded-lg border border-border lg:block">
         <Table>
           <TableHeader>
             <TableRow>

--- a/apps/staff/components/scholar-profile.tsx
+++ b/apps/staff/components/scholar-profile.tsx
@@ -217,12 +217,12 @@ export function ScholarProfilePage({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
-        <Button variant="ghost" onClick={onBack}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button variant="ghost" className="w-fit" onClick={onBack}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back to Students
         </Button>
-        <div className="flex items-center gap-2">
+        <div className="grid grid-cols-2 gap-2 sm:flex sm:items-center">
           <Dialog
             open={editOpen}
             onOpenChange={(open) => {
@@ -500,69 +500,82 @@ export function ScholarProfilePage({
             className="bg-ashinaga-teal-600 hover:bg-ashinaga-teal-700"
           >
             <Download className="h-4 w-4 mr-2" />
-            Download LDF Report
+            <span className="sm:hidden">Download LDF</span>
+            <span className="hidden sm:inline">Download LDF Report</span>
           </Button>
         </div>
       </div>
 
       {/* Student Info Card */}
       <Card>
-        <CardContent className="pt-6">
-          <div className="flex items-start gap-6">
-            <Avatar className="h-20 w-20">
-              <AvatarImage src={scholar.image || '/placeholder.svg'} />
-              <AvatarFallback className="text-lg">
-                {scholar.name
-                  .split(' ')
-                  .map((n) => n[0])
-                  .join('')}
-              </AvatarFallback>
-            </Avatar>
-            <div className="flex-1">
-              <div className="flex items-center gap-3 mb-2">
-                <h1 className="text-2xl font-bold">{scholar.name}</h1>
-                <Badge
-                  className={
-                    scholar.status === 'archived'
-                      ? 'bg-muted text-foreground'
-                      : scholar.status === 'active'
-                        ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
-                        : 'bg-amber-100 text-amber-800'
-                  }
-                >
-                  {scholar.status}
-                </Badge>
-              </div>
-              <p className="text-muted-foreground mb-4">{scholar.bio || 'No bio available'}</p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-                <div className="flex items-center gap-2">
-                  <Mail className="h-4 w-4 text-muted-foreground" />
-                  <span>{scholar.email}</span>
+        <CardContent className="p-4 sm:p-6">
+          <div className="flex flex-col gap-5 lg:flex-row lg:items-start">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start lg:flex-1">
+              <Avatar className="h-16 w-16 shrink-0 sm:h-20 sm:w-20">
+                <AvatarImage src={scholar.image || '/placeholder.svg'} />
+                <AvatarFallback className="text-lg">
+                  {scholar.name
+                    .split(' ')
+                    .map((n) => n[0])
+                    .join('')}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0 flex-1">
+                <div className="mb-2 flex flex-wrap items-center gap-2">
+                  <h1 className="min-w-0 text-2xl font-bold leading-tight">{scholar.name}</h1>
+                  <Badge
+                    className={
+                      scholar.status === 'archived'
+                        ? 'bg-muted text-foreground'
+                        : scholar.status === 'active'
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
+                          : 'bg-amber-100 text-amber-800'
+                    }
+                  >
+                    {scholar.status}
+                  </Badge>
                 </div>
-                <div className="flex items-center gap-2">
-                  <Phone className="h-4 w-4 text-muted-foreground" />
-                  <span>{scholar.phone || 'No phone number'}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <MapPin
-                    className="h-4 w-4 text-muted-foreground shrink-0"
-                    aria-label="Country of study"
-                  />
-                  <span>{normalizeLocation(scholar.location ?? '') || 'No location'}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Calendar className="h-4 w-4 text-muted-foreground" />
-                  <span>Started {new Date(scholar.startDate).toLocaleDateString()}</span>
+                <p className="mb-4 text-muted-foreground">{scholar.bio || 'No bio available'}</p>
+                <div className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Mail className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 truncate">{scholar.email}</span>
+                  </div>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Phone className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 truncate">{scholar.phone || 'No phone number'}</span>
+                  </div>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <MapPin
+                      className="h-4 w-4 shrink-0 text-muted-foreground"
+                      aria-label="Country of study"
+                    />
+                    <span className="min-w-0 truncate">
+                      {normalizeLocation(scholar.location ?? '') || 'No location'}
+                    </span>
+                  </div>
+                  <div className="flex min-w-0 items-center gap-2">
+                    <Calendar className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 truncate">
+                      Started {new Date(scholar.startDate).toLocaleDateString()}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
-            <div className="text-right">
-              <p className="text-sm text-muted-foreground">Program</p>
-              <p className="font-medium">{scholar.program}</p>
-              <p className="text-sm text-muted-foreground mt-2">Year</p>
-              <Badge variant="outline">{scholar.year}</Badge>
-              <p className="text-sm text-muted-foreground mt-2">University</p>
-              <p className="font-medium text-sm">{scholar.university}</p>
+            <div className="grid grid-cols-1 gap-3 border-t pt-4 text-sm sm:grid-cols-3 lg:w-56 lg:shrink-0 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
+              <div className="min-w-0">
+                <p className="text-muted-foreground">Program</p>
+                <p className="font-medium">{scholar.program}</p>
+              </div>
+              <div className="min-w-0">
+                <p className="text-muted-foreground">Year</p>
+                <Badge variant="outline">{scholar.year}</Badge>
+              </div>
+              <div className="min-w-0 sm:col-span-3 lg:col-span-1">
+                <p className="text-muted-foreground">University</p>
+                <p className="font-medium">{scholar.university}</p>
+              </div>
             </div>
           </div>
         </CardContent>
@@ -570,12 +583,14 @@ export function ScholarProfilePage({
 
       {/* Tabs */}
       <Tabs defaultValue={initialTab} className="space-y-4">
-        <TabsList>
-          <TabsTrigger value="profile">Profile</TabsTrigger>
-          <TabsTrigger value="goals">LDF Goals</TabsTrigger>
-          <TabsTrigger value="tasks">Tasks</TabsTrigger>
-          <TabsTrigger value="documents">Documents</TabsTrigger>
-        </TabsList>
+        <div className="-mx-3 overflow-x-auto px-3 sm:mx-0 sm:px-0">
+          <TabsList className="w-max sm:w-auto">
+            <TabsTrigger value="profile">Profile</TabsTrigger>
+            <TabsTrigger value="goals">LDF Goals</TabsTrigger>
+            <TabsTrigger value="tasks">Tasks</TabsTrigger>
+            <TabsTrigger value="documents">Documents</TabsTrigger>
+          </TabsList>
+        </div>
 
         <TabsContent value="profile" className="space-y-4">
           <Card>

--- a/apps/staff/components/theme-toggle.tsx
+++ b/apps/staff/components/theme-toggle.tsx
@@ -15,9 +15,14 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <Button variant="ghost" size="sm" className="justify-start text-muted-foreground">
-        <Sun className="mr-2 h-4 w-4" />
-        Light Mode
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-8 w-8 px-0 text-muted-foreground sm:w-auto sm:px-3"
+        aria-label="Switch theme"
+      >
+        <Sun className="h-4 w-4 sm:mr-2" />
+        <span className="hidden sm:inline">Light Mode</span>
       </Button>
     );
   }
@@ -28,18 +33,19 @@ export function ThemeToggle() {
     <Button
       variant="ghost"
       size="sm"
-      className="justify-start text-muted-foreground hover:text-foreground"
+      className="h-8 w-8 px-0 text-muted-foreground hover:text-foreground sm:w-auto sm:px-3"
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {isDark ? (
         <>
-          <Sun className="mr-2 h-4 w-4" />
-          Light Mode
+          <Sun className="h-4 w-4 sm:mr-2" />
+          <span className="hidden sm:inline">Light Mode</span>
         </>
       ) : (
         <>
-          <Moon className="mr-2 h-4 w-4" />
-          Dark Mode
+          <Moon className="h-4 w-4 sm:mr-2" />
+          <span className="hidden sm:inline">Dark Mode</span>
         </>
       )}
     </Button>

--- a/apps/staff/test/e2e/staff-features.e2e-spec.ts
+++ b/apps/staff/test/e2e/staff-features.e2e-spec.ts
@@ -87,7 +87,7 @@ test.describe('Staff Portal – new features', () => {
     page,
   }) => {
     // Quick Actions launcher on the dashboard (label was shortened in the UI uplift)
-    await page.getByRole('button', { name: /^Assign Task$/i }).click();
+    await page.getByRole('button', { name: /^Assign Task/i }).click();
     await expect(page.getByRole('dialog')).toBeVisible();
 
     const titleInput = page.getByLabel(/Task Title/i);


### PR DESCRIPTION
## Summary

- Improved staff app mobile responsiveness across navigation, scholar profiles, requests, and invitations.
- Reworked cramped mobile layouts into stacked/card-based views where desktop tables were overflowing.
- Added mobile-friendly selectors for staff app navigation and invitation tabs.
- Fixed button/action overflow issues, including request actions, delete controls, and Download LDF/profile actions.

## PR Checklist (Skills)

- [ ] If this PR adds or changes a skill package (`packages/*` with `SKILL.md`), `scripts.dev` points to `src/dev.ts` (non-blocking in root `pnpm dev`).
- [ ] Skill wrapper behavior verified:
  - [ ] No args => exits `0` with skip message
  - [ ] With args => runs intended skill logic
- [ ] `.env.example` exists in the skill package and contains placeholders only (no real secrets).
- [ ] `SKILL.md` documents `.env.example` -> `.env.local` setup and required env vars.
- [ ] `pnpm check:skills` passes locally.
- [ ] `pnpm lint` passes locally.
- [ ] Root `pnpm dev` does not fail because of this skill package (any remaining failures are unrelated and noted below).

## Validation Notes

- `pnpm check:skills`: Not run; no skill packages changed.
- `pnpm lint`: Not run end-to-end. Ran Biome checks on changed staff files.
- `pnpm dev` (root) outcome: Not run.
- Any unrelated blockers (ports/services/etc.): `pnpm --filter staff build` compiled successfully, then failed during type checking because `apps/staff/test/e2e/auth.setup.ts` cannot resolve `pg`; this appears unrelated to the responsive UI changes.