### PR TITLE
ASH-12 Fix scoped request stats

### DIFF
--- a/apps/api/src/requests/requests.controller.spec.ts
+++ b/apps/api/src/requests/requests.controller.spec.ts
@@ -1,5 +1,6 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
+import { UnauthorizedException } from '@nestjs/common';
 import { RequestsController } from './requests.controller';
 import { RequestsService } from './requests.service';
 
@@ -109,12 +110,27 @@ describe('RequestsController', () => {
         commented: 1,
       };
 
+      const mockRequest = {
+        user: {
+          id: 'user-123',
+          email: 'test@example.com',
+        },
+      };
+
       mockRequestsService.getRequestStats.mockResolvedValue(mockStats);
 
-      const result = await controller.getRequestStats();
+      const result = await controller.getRequestStats(mockRequest as any);
 
-      expect(service.getRequestStats).toHaveBeenCalled();
+      expect(service.getRequestStats).toHaveBeenCalledWith('user-123');
       expect(result).toEqual(mockStats);
+    });
+
+    it('should reject request statistics without an authenticated user', async () => {
+      await expect(controller.getRequestStats({} as any)).rejects.toBeInstanceOf(
+        UnauthorizedException
+      );
+
+      expect(service.getRequestStats).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/requests/requests.controller.ts
+++ b/apps/api/src/requests/requests.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Query,
   Req,
+  UnauthorizedException,
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
@@ -46,7 +47,8 @@ export class RequestsController {
   }
 
   @Get('stats')
-  async getRequestStats(): Promise<{
+  @UseGuards(AuthGuard)
+  async getRequestStats(@Req() req: AuthenticatedRequest): Promise<{
     total: number;
     pending: number;
     approved: number;
@@ -54,7 +56,11 @@ export class RequestsController {
     reviewed: number;
     commented: number;
   }> {
-    return this.requestsService.getRequestStats();
+    const userId = req.user?.id;
+    if (!userId) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+    return this.requestsService.getRequestStats(userId);
   }
 
   @Post(':id/status')

--- a/apps/api/src/requests/requests.service.spec.ts
+++ b/apps/api/src/requests/requests.service.spec.ts
@@ -139,26 +139,111 @@ describe('RequestsService', () => {
   });
 
   describe('getRequestStats', () => {
-    it('should return aggregated statistics', async () => {
-      const mockStats = [
-        { status: 'pending', count: 10 },
-        { status: 'approved', count: 5 },
-        { status: 'rejected', count: 3 },
-      ];
+    const mockStats = [
+      { status: 'pending', count: 10 },
+      { status: 'approved', count: 5 },
+      { status: 'rejected', count: 3 },
+    ];
 
+    function mockRequestStatsQueries({
+      isSuperAdmin,
+    }: {
+      isSuperAdmin: boolean;
+    }) {
       const mockDatabase = require('../db/connection').database;
-      mockDatabase.select = jest.fn().mockReturnValue({
+      const statsWhereMock = jest.fn().mockReturnValue({
+        groupBy: jest.fn().mockResolvedValue(mockStats),
+      });
+      const assigneeWhereMock = jest.fn().mockReturnValue({ scopedToAssignee: true });
+
+      const staffQuery = {
         from: jest.fn().mockReturnValue({
-          groupBy: jest.fn().mockResolvedValue(mockStats),
+          where: jest.fn().mockResolvedValue([{ isSuperAdmin }]),
         }),
+      };
+
+      const assigneeSubquery = {
+        from: jest.fn().mockReturnValue({
+          where: assigneeWhereMock,
+        }),
+      };
+
+      const statsQuery = {
+        from: jest.fn().mockReturnValue({
+          where: statsWhereMock,
+        }),
+      };
+
+      mockDatabase.select = jest
+        .fn()
+        .mockReturnValueOnce(staffQuery)
+        .mockReturnValueOnce(isSuperAdmin ? statsQuery : assigneeSubquery);
+
+      if (!isSuperAdmin) {
+        mockDatabase.select.mockReturnValueOnce(statsQuery);
+      }
+
+      return { assigneeWhereMock, statsWhereMock };
+    }
+
+    it('should return assigned request statistics for regular staff', async () => {
+      const { assigneeWhereMock, statsWhereMock } = mockRequestStatsQueries({
+        isSuperAdmin: false,
       });
 
-      const result = await service.getRequestStats();
+      const result = await service.getRequestStats('user-123');
 
       expect(result.total).toBe(18);
       expect(result.pending).toBe(10);
       expect(result.approved).toBe(5);
       expect(result.rejected).toBe(3);
+      expect(assigneeWhereMock).toHaveBeenCalled();
+      expect(statsWhereMock).toHaveBeenCalled();
+    });
+
+    it('should return all active request statistics for super admins', async () => {
+      const { assigneeWhereMock, statsWhereMock } = mockRequestStatsQueries({
+        isSuperAdmin: true,
+      });
+
+      const result = await service.getRequestStats('super-admin-123');
+
+      expect(result.total).toBe(18);
+      expect(result.pending).toBe(10);
+      expect(result.approved).toBe(5);
+      expect(result.rejected).toBe(3);
+      expect(assigneeWhereMock).not.toHaveBeenCalled();
+      expect(statsWhereMock).toHaveBeenCalled();
+    });
+
+    it('should return zero counts when no visible requests match', async () => {
+      const mockDatabase = require('../db/connection').database;
+
+      mockDatabase.select = jest
+        .fn()
+        .mockReturnValueOnce({
+          from: jest.fn().mockReturnValue({
+            where: jest.fn().mockResolvedValue([{ isSuperAdmin: true }]),
+          }),
+        })
+        .mockReturnValueOnce({
+          from: jest.fn().mockReturnValue({
+            where: jest.fn().mockReturnValue({
+              groupBy: jest.fn().mockResolvedValue([]),
+            }),
+          }),
+        });
+
+      const result = await service.getRequestStats('super-admin-123');
+
+      expect(result).toEqual({
+        total: 0,
+        pending: 0,
+        approved: 0,
+        rejected: 0,
+        reviewed: 0,
+        commented: 0,
+      });
     });
   });
 });

--- a/apps/api/src/requests/requests.service.ts
+++ b/apps/api/src/requests/requests.service.ts
@@ -209,7 +209,7 @@ export class RequestsService {
     return auditLogs;
   }
 
-  async getRequestStats(): Promise<{
+  async getRequestStats(userId: string): Promise<{
     total: number;
     pending: number;
     approved: number;
@@ -217,12 +217,27 @@ export class RequestsService {
     reviewed: number;
     commented: number;
   }> {
+    const whereConditions = [eq(requests.archived, false)];
+
+    // Match getRequests visibility: super admins see all active requests,
+    // regular staff only see requests assigned to them.
+    const [staffRecord] = await database.select().from(staff).where(eq(staff.userId, userId));
+
+    if (!staffRecord?.isSuperAdmin) {
+      const assignedRequestIds = database
+        .select({ requestId: requestAssignees.requestId })
+        .from(requestAssignees)
+        .where(eq(requestAssignees.userId, userId));
+      whereConditions.push(inArray(requests.id, assignedRequestIds));
+    }
+
     const statsResult = await database
       .select({
         status: requests.status,
         count: count(),
       })
       .from(requests)
+      .where(and(...whereConditions))
       .groupBy(requests.status);
 
     const stats = {

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -323,9 +323,8 @@ function StaffDashboardContent() {
 
   const handleRequestStatusUpdate = (requestId: string, status: string, comment?: string) => {
     console.log('Request updated:', { requestId, status, comment });
-    // In real app, update the request status in your state/API
-    // For now, just refetch the data
     fetchRequests();
+    fetchRequestStats();
   };
 
   const navigateToScholars = () => {


### PR DESCRIPTION
## Summary

- Fixed the Overview “Pending Requests” metric so regular staff only see counts for requests assigned to them, matching what appears in their Requests tab.
- Super admins still see counts across all active requests.
- Archived requests are now excluded from request stats.
- Refetched request stats after request status changes or archive/delete actions so the Overview card updates without a full page refresh.
- Added/updated API tests to cover authenticated, scoped request stats behaviour.

## PR Checklist (Skills)

- [x] Not applicable: this PR does not add or change a skill package (`packages/*` with `SKILL.md`).
- [x] Not applicable: skill wrapper behavior unchanged.
- [x] Not applicable: no skill package `.env.example` changes.
- [x] Not applicable: no `SKILL.md` changes.
- [ ] `pnpm check:skills` passes locally.
- [ ] `pnpm lint` passes locally.
- [ ] Root `pnpm dev` does not fail because of this skill package (any remaining failures are unrelated and noted below).

## Validation Notes

- `pnpm check:skills`: Not run; no skill packages changed.
- `pnpm lint`: Not run.
- `pnpm dev` (root) outcome: Not run.
- API focused tests: `corepack pnpm test -- requests` passed.
- API build: `corepack pnpm build` passed.