### PR TITLE
feat(staff): add "Request More Information" action for funding requests

### DIFF
--- a/apps/staff/components/__tests__/request-management.test.tsx
+++ b/apps/staff/components/__tests__/request-management.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Request } from '../../lib/api-client';
+import { RequestManagement } from '../request-management';
+
+const mockToast = jest.fn();
+
+// lucide-react ships as ESM, which Jest's transform ignores under node_modules.
+// Stub every icon with a no-op component so the icons don't break the render.
+jest.mock(
+  'lucide-react',
+  () =>
+    new Proxy(
+      {},
+      {
+        get: (_target, prop) => (prop === '__esModule' ? true : () => null),
+      }
+    )
+);
+
+jest.mock('../../lib/api-client', () => ({
+  updateRequestStatus: jest.fn().mockResolvedValue({}),
+  deleteRequest: jest.fn(),
+  getFileDownloadUrl: jest.fn(),
+}));
+
+jest.mock('../../lib/auth-client', () => ({
+  useSession: jest.fn(),
+}));
+
+jest.mock('../ui/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// Pull in the mocked modules so we can assert against them.
+const { updateRequestStatus } = jest.requireMock('../../lib/api-client') as {
+  updateRequestStatus: jest.Mock;
+};
+const { useSession } = jest.requireMock('../../lib/auth-client') as {
+  useSession: jest.Mock;
+};
+
+function buildRequest(overrides: Partial<Request> = {}): Request {
+  return {
+    id: 'req-1',
+    scholarId: 'scholar-1',
+    scholarName: 'Test Scholar',
+    scholarEmail: 'scholar@example.com',
+    type: 'summer_funding_request',
+    description: 'Summer funding application',
+    formData: null,
+    priority: 'medium',
+    status: 'pending',
+    submittedDate: '2026-01-01T00:00:00.000Z',
+    reviewedBy: null,
+    reviewComment: null,
+    reviewDate: null,
+    assignees: [],
+    attachments: [],
+    auditLogs: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('RequestManagement — Request More Information (commented) action', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useSession.mockReturnValue({
+      data: { user: { id: 'staff-1', email: 'staff@example.com' } },
+      isPending: false,
+    });
+  });
+
+  it('exposes a "Request More Information" button in the review dialog for a pending request', async () => {
+    const user = userEvent.setup();
+    render(<RequestManagement request={buildRequest()} onStatusUpdate={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /^Review$/i }));
+
+    expect(
+      await screen.findByRole('button', { name: /Request More Information/i })
+    ).toBeInTheDocument();
+  });
+
+  it('sets the request status to "commented" with the staff comment when info is requested', async () => {
+    const user = userEvent.setup();
+    const onStatusUpdate = jest.fn();
+    render(<RequestManagement request={buildRequest()} onStatusUpdate={onStatusUpdate} />);
+
+    await user.click(screen.getByRole('button', { name: /^Review$/i }));
+
+    const commentBox = await screen.findByLabelText(/Comments/i);
+    await user.type(commentBox, 'Please attach your bank statement.');
+
+    await user.click(screen.getByRole('button', { name: /Request More Information/i }));
+
+    await waitFor(() => {
+      expect(updateRequestStatus).toHaveBeenCalledWith(
+        'req-1',
+        'commented',
+        'Please attach your bank statement.',
+        'staff-1'
+      );
+    });
+    expect(onStatusUpdate).toHaveBeenCalledWith(
+      'req-1',
+      'commented',
+      'Please attach your bank statement.'
+    );
+  });
+
+  it('requires a comment before requesting more information', async () => {
+    const user = userEvent.setup();
+    render(<RequestManagement request={buildRequest()} onStatusUpdate={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /^Review$/i }));
+    await user.click(await screen.findByRole('button', { name: /Request More Information/i }));
+
+    expect(updateRequestStatus).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+  });
+});

--- a/apps/staff/components/request-management.tsx
+++ b/apps/staff/components/request-management.tsx
@@ -1,6 +1,15 @@
 'use client';
 
-import { CheckCircle, Clock, Download, Eye, Paperclip, Trash2, X } from 'lucide-react';
+import {
+  CheckCircle,
+  Clock,
+  Download,
+  Eye,
+  MessageSquare,
+  Paperclip,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { useState } from 'react';
 import {
   deleteRequest,
@@ -31,7 +40,7 @@ interface RequestManagementProps {
   onStatusUpdate: (requestId: string, status: string, comment?: string) => void;
 }
 
-type ReviewStatus = 'approved' | 'rejected' | 'reviewed';
+type ReviewStatus = 'approved' | 'rejected' | 'reviewed' | 'commented';
 
 export function RequestManagement({ request, onStatusUpdate }: RequestManagementProps) {
   const [approvalOpen, setApprovalOpen] = useState(false);
@@ -72,6 +81,18 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
 
   const handleApproval = async (approved: boolean) => {
     await handleStatusUpdate(approved ? 'approved' : 'rejected');
+  };
+
+  const handleRequestInfo = async () => {
+    if (!approvalComment.trim()) {
+      toast({
+        title: 'Comment required',
+        description: 'Please describe what additional information the scholar needs to provide.',
+        variant: 'destructive',
+      });
+      return;
+    }
+    await handleStatusUpdate('commented');
   };
 
   const handleDownload = async (attachmentId: string, filename: string) => {
@@ -347,6 +368,15 @@ export function RequestManagement({ request, onStatusUpdate }: RequestManagement
                       >
                         <X className="h-4 w-4 mr-2" />
                         {isSubmitting ? 'Processing...' : 'Reject'}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={handleRequestInfo}
+                        disabled={isSubmitting}
+                        className="text-blue-700 border-blue-200 hover:bg-blue-50"
+                      >
+                        <MessageSquare className="h-4 w-4 mr-2" />
+                        {isSubmitting ? 'Processing...' : 'Request More Information'}
                       </Button>
                       {request.status !== 'reviewed' && (
                         <Button


### PR DESCRIPTION
## Problem

Ody reported that the **Summer funding – additional information requests** feature wasn't working: there was no option in the staff app to mark a request as **commented**, even though "Commented" shows up in the Requests status filter.

## Root cause

The `commented` status was fully supported everywhere *except* the staff UI action:

| Layer | Supported `commented`? |
|-------|------------------------|
| DB enum (`request_status`) | ✅ |
| API `POST /api/requests/:id/status` | ✅ |
| Service logic + email notifications | ✅ |
| Status **filter** dropdown | ✅ (why it was visible) |
| Scholar app — respond to a commented request | ✅ |
| **Staff review dialog — button to set `commented`** | ❌ **missing** |

So the intended workflow (staff request more info → request goes to `commented` → scholar responds → reopens to `pending`) could never be triggered from the staff side. The scholar side was already built and waiting.

## Change

- Add a **"Request More Information"** button to the staff review dialog, wired to the already-working `updateRequestStatus(..., 'commented', ...)` call.
- Require a comment for this action so the scholar knows what to provide.
- Add `'commented'` to the `ReviewStatus` type.
- Add unit tests (`request-management.test.tsx`) covering: the button renders, the API call fires with `commented` + comment, and the required-comment validation.

## Testing

- `pnpm exec jest` in `apps/staff` — 6 passed (3 new)
- Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Request More Information" action to the request review dialog. Staff can now provide detailed feedback and request additional information from requesters by entering a comment before confirming. Comments are required to submit this action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->