### PR TITLE
ASH-75 Fix invitation expiry resend

### DIFF
--- a/apps/api/src/invitations/invitations.service.spec.ts
+++ b/apps/api/src/invitations/invitations.service.spec.ts
@@ -1,9 +1,25 @@
 import { ConfigService } from '@nestjs/config';
 import { Test, type TestingModule } from '@nestjs/testing';
+import { getDatabase } from '../db/connection';
 import { InvitationsService } from './invitations.service';
+
+jest.mock('../db/connection', () => ({
+  getDatabase: jest.fn(),
+}));
 
 describe('InvitationsService', () => {
   let service: InvitationsService;
+
+  const mockConfigService = {
+    get: jest.fn((key: string, defaultValue?: string) => {
+      const config: Record<string, string> = {
+        BETTER_AUTH_URL: 'http://localhost:4000',
+        SCHOLAR_APP_URL: 'http://localhost:4002',
+        STAFF_APP_URL: 'http://localhost:4001',
+      };
+      return config[key] || defaultValue;
+    }),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -11,22 +27,177 @@ describe('InvitationsService', () => {
         InvitationsService,
         {
           provide: ConfigService,
-          useValue: {
-            get: jest.fn((key: string) => {
-              const config: Record<string, any> = {
-                BETTER_AUTH_URL: 'http://localhost:4000',
-              };
-              return config[key];
-            }),
-          },
+          useValue: mockConfigService,
         },
       ],
     }).compile();
 
     service = module.get<InvitationsService>(InvitationsService);
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('marks stale pending invitations as expired before listing invitations', async () => {
+    const expiredSet = jest.fn().mockReturnValue({
+      where: jest.fn().mockResolvedValue(undefined),
+    });
+    const listResults = [
+      {
+        id: 'invitation-1',
+        email: 'scholar@example.com',
+        userType: 'scholar',
+        status: 'expired',
+        expiresAt: new Date('2026-05-20T00:00:00.000Z'),
+        acceptedAt: null,
+        sentAt: new Date('2026-05-13T00:00:00.000Z'),
+        lastResentAt: null,
+        resentCount: '0',
+        invitedBy: 'staff-1',
+        createdAt: new Date('2026-05-13T00:00:00.000Z'),
+      },
+    ];
+    const orderBy = jest.fn().mockResolvedValue(listResults);
+
+    const db = {
+      update: jest.fn().mockReturnValue({ set: expiredSet }),
+      select: jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          orderBy,
+        }),
+      }),
+    };
+    (getDatabase as jest.Mock).mockReturnValue(db);
+
+    const result = await service.listInvitations();
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(expiredSet).toHaveBeenCalledWith({
+      status: 'expired',
+      updatedAt: expect.any(Date),
+    });
+    expect(orderBy).toHaveBeenCalled();
+    expect(result).toEqual(listResults);
+  });
+
+  it('filters after reconciling expired pending invitations', async () => {
+    const expiredSet = jest.fn().mockReturnValue({
+      where: jest.fn().mockResolvedValue(undefined),
+    });
+    const where = jest.fn().mockReturnValue({
+      orderBy: jest.fn().mockResolvedValue([]),
+    });
+
+    const db = {
+      update: jest.fn().mockReturnValue({ set: expiredSet }),
+      select: jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where,
+        }),
+      }),
+    };
+    (getDatabase as jest.Mock).mockReturnValue(db);
+
+    await service.listInvitations('expired');
+
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(expiredSet).toHaveBeenCalledWith({
+      status: 'expired',
+      updatedAt: expect.any(Date),
+    });
+    expect(where).toHaveBeenCalled();
+  });
+
+  it('resends an expired invitation by making it pending and refreshing expiry', async () => {
+    const expiredInvitation = {
+      id: 'invitation-1',
+      email: 'scholar@example.com',
+      userType: 'scholar',
+      status: 'expired',
+      token: 'token-123',
+      expiresAt: new Date('2026-05-20T00:00:00.000Z'),
+      resentCount: '2',
+    };
+    const setCalls: Array<Record<string, unknown>> = [];
+    const set = jest.fn((values: Record<string, unknown>) => {
+      setCalls.push(values);
+      return {
+        where: jest.fn().mockResolvedValue(undefined),
+      };
+    });
+    const limit = jest.fn().mockResolvedValue([expiredInvitation]);
+
+    const db = {
+      update: jest.fn().mockReturnValue({ set }),
+      select: jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit,
+          }),
+        }),
+      }),
+    };
+    (getDatabase as jest.Mock).mockReturnValue(db);
+    jest
+      .spyOn(
+        service as unknown as {
+          sendInvitationEmail: (
+            email: string,
+            inviteUrl: string,
+            userType: string
+          ) => Promise<void>;
+        },
+        'sendInvitationEmail'
+      )
+      .mockResolvedValue(undefined);
+
+    const result = await service.resendInvitation('invitation-1', 'staff-1');
+    const resendUpdate = setCalls[1];
+
+    expect(result).toEqual({
+      message: 'Invitation resent successfully',
+      resentCount: 3,
+    });
+    expect(resendUpdate).toMatchObject({
+      status: 'pending',
+      lastResentAt: expect.any(Date),
+      resentCount: '3',
+      updatedAt: expect.any(Date),
+    });
+    expect(resendUpdate.expiresAt).toBeInstanceOf(Date);
+    expect((resendUpdate.expiresAt as Date).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('keeps non-resendable invitation statuses blocked', async () => {
+    const acceptedInvitation = {
+      id: 'invitation-1',
+      email: 'scholar@example.com',
+      userType: 'scholar',
+      status: 'accepted',
+      token: 'token-123',
+      expiresAt: new Date('2026-07-20T00:00:00.000Z'),
+      resentCount: '0',
+    };
+    const set = jest.fn().mockReturnValue({
+      where: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const db = {
+      update: jest.fn().mockReturnValue({ set }),
+      select: jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([acceptedInvitation]),
+          }),
+        }),
+      }),
+    };
+    (getDatabase as jest.Mock).mockReturnValue(db);
+
+    await expect(service.resendInvitation('invitation-1', 'staff-1')).rejects.toThrow(
+      'Cannot resend invitation with status: accepted'
+    );
   });
 });

--- a/apps/api/src/invitations/invitations.service.ts
+++ b/apps/api/src/invitations/invitations.service.ts
@@ -109,8 +109,10 @@ export class InvitationsService {
     };
   }
 
-  async resendInvitation(invitationId: string, requestingUserId: string) {
+  async resendInvitation(invitationId: string, _requestingUserId: string) {
     const db = getDatabase();
+
+    await this.markExpiredPendingInvitations();
 
     // Get the invitation
     const [invitation] = await db
@@ -123,7 +125,7 @@ export class InvitationsService {
       throw new NotFoundException('Invitation not found');
     }
 
-    if (invitation.status !== 'pending') {
+    if (invitation.status !== 'pending' && invitation.status !== 'expired') {
       throw new BadRequestException(`Cannot resend invitation with status: ${invitation.status}`);
     }
 
@@ -133,8 +135,6 @@ export class InvitationsService {
       throw new BadRequestException('Maximum resend limit reached for this invitation');
     }
 
-    // If the invitation has passed its expiry, extend it so the resent link is usable.
-    const isExpired = new Date() > new Date(invitation.expiresAt);
     const newExpiresAt = new Date();
     newExpiresAt.setDate(newExpiresAt.getDate() + 30);
 
@@ -146,9 +146,10 @@ export class InvitationsService {
     await db
       .update(invitations)
       .set({
+        status: 'pending',
+        expiresAt: newExpiresAt,
         lastResentAt: new Date(),
         resentCount: String(resentCount + 1),
-        ...(isExpired ? { expiresAt: newExpiresAt } : {}),
         updatedAt: new Date(),
       })
       .where(eq(invitations.id, invitationId));
@@ -161,6 +162,8 @@ export class InvitationsService {
 
   async listInvitations(status?: 'pending' | 'accepted' | 'expired' | 'cancelled') {
     const db = getDatabase();
+
+    await this.markExpiredPendingInvitations();
 
     const baseQuery = db
       .select({
@@ -184,7 +187,7 @@ export class InvitationsService {
     return results;
   }
 
-  async cancelInvitation(invitationId: string, cancelledBy: string) {
+  async cancelInvitation(invitationId: string, _cancelledBy: string) {
     const db = getDatabase();
 
     const [invitation] = await db
@@ -256,6 +259,15 @@ export class InvitationsService {
       scholarData,
       expiresAt: invitation.expiresAt,
     };
+  }
+
+  private async markExpiredPendingInvitations() {
+    const db = getDatabase();
+
+    await db
+      .update(invitations)
+      .set({ status: 'expired', updatedAt: new Date() })
+      .where(sql`${invitations.status} = 'pending' and ${invitations.expiresAt} < now()`);
   }
 
   private buildInviteUrl(token: string, userType: string): string {

--- a/apps/staff/components/invitations-management.tsx
+++ b/apps/staff/components/invitations-management.tsx
@@ -192,6 +192,7 @@ function InvitationList({ userType }: InvitationListProps) {
             {filtered.map((inv) => {
               const expires = new Date(inv.expiresAt);
               const isPending = inv.status === 'pending';
+              const canResend = inv.status === 'pending' || inv.status === 'expired';
               return (
                 <li key={inv.id} className="rounded-lg border p-4">
                   <div className="flex items-start justify-between gap-3">
@@ -229,7 +230,7 @@ function InvitationList({ userType }: InvitationListProps) {
                       type="button"
                       variant="outline"
                       size="sm"
-                      disabled={!isPending || busyId !== null}
+                      disabled={!canResend || busyId !== null}
                       onClick={() => handleResend(inv.id)}
                     >
                       {busyId === inv.id ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Resend'}
@@ -261,6 +262,7 @@ function InvitationList({ userType }: InvitationListProps) {
               {filtered.map((inv) => {
                 const expires = new Date(inv.expiresAt);
                 const isPending = inv.status === 'pending';
+                const canResend = inv.status === 'pending' || inv.status === 'expired';
                 return (
                   <li
                     key={inv.id}
@@ -286,7 +288,7 @@ function InvitationList({ userType }: InvitationListProps) {
                         type="button"
                         variant="outline"
                         size="sm"
-                        disabled={!isPending || busyId !== null}
+                        disabled={!canResend || busyId !== null}
                         onClick={() => handleResend(inv.id)}
                       >
                         {busyId === inv.id ? (


### PR DESCRIPTION
## Summary

- Fixed stale pending invitations that had passed `expires_at` but still appeared as pending in the staff UI.
- Updated invitation listing to mark expired pending invitations as `expired` before returning results.
- Allowed expired invitations to be resent, which resets them to `pending`, refreshes `expiresAt` for 30 days, and increments the resend count.
- Enabled the staff UI resend action for expired invitations.
- Added unit tests for expiry reconciliation and resend behaviour.

## PR Checklist (Skills)

- [x] If this PR adds or changes a skill package (`packages/*` with `SKILL.md`), `scripts.dev` points to `src/dev.ts` (non-blocking in root `pnpm dev`). N/A, no skill package changes.
- [x] Skill wrapper behavior verified: N/A, no skill package changes.
  - [x] No args => exits `0` with skip message. N/A.
  - [x] With args => runs intended skill logic. N/A.
- [x] `.env.example` exists in the skill package and contains placeholders only (no real secrets). N/A.
- [x] `SKILL.md` documents `.env.example` -> `.env.local` setup and required env vars. N/A.
- [ ] `pnpm check:skills` passes locally.
- [ ] `pnpm lint` passes locally.
- [ ] Root `pnpm dev` does not fail because of this skill package (any remaining failures are unrelated and noted below).

## Validation Notes

- `pnpm check:skills`: Not run. This PR does not touch skill packages.
- Ran targeted Biome checks:
  - `node_modules\.bin\biome.CMD check apps\api\src\invitations\invitations.service.ts apps\staff\components\invitations-management.tsx`
  - `node_modules\.bin\biome.CMD check apps\api\src\invitations\invitations.service.spec.ts`
- Targeted tests:
  - `apps\api\node_modules\.bin\jest.CMD --config apps\api\jest.config.ts apps/api/src/invitations/invitations.service.spec.ts --runInBand`
  - Result: passed, 5 tests.
- `pnpm dev` (root) outcome: Not run. No skill package changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invitations can now be resent after expiring, allowing admins to re-engage users who missed the original deadline.

* **Improvements**
  * The system now automatically marks pending invitations as expired once they pass their expiration date, ensuring accurate status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->