### PR TITLE
Set up Cursor Cloud dev environment (docs + Docker bootstrap helper)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "bash ./scripts/_docker_install.sh",
+  "start": "bash ./scripts/_docker_install.sh"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Turborepo + pnpm monorepo. The standard commands in `README.md`, `CLAUDE.md`, and the per-app `package.json` scripts are accurate — use them. The notes below only cover non-obvious, environment-specific caveats for running things in the Cloud VM.
+
+### Services (dev mode)
+- `apps/api` — NestJS (Fastify) API on `http://localhost:4000` (Swagger at `/api`, health at `/health`). Requires Postgres.
+- `apps/staff` — Next.js staff portal on `http://localhost:4001`.
+- `apps/scholar` — Next.js scholar portal on `http://localhost:4002`.
+- `packages/ui` — Storybook on `http://localhost:6006`.
+
+Note: `README.md`/`docs` mention ports 3000/3001/3002, but the actual dev ports are **4000/4001/4002** (see `apps/*/package.json` and `apps/api/.env.example`).
+
+### Postgres runs in Docker (must be started manually)
+- Postgres 17.5 runs via `docker compose up -d postgres` and is published on host port **5433** (not 5432). See `docker-compose.yml`.
+- Docker is pre-installed in the VM snapshot, but `dockerd` is **not** running on boot. Start it once per session:
+  - `sudo bash -c 'nohup dockerd > /tmp/dockerd.log 2>&1 &'` then `sudo chmod 666 /var/run/docker.sock` so `docker` works without sudo (Turbo's `pnpm dev` calls `docker compose` directly).
+- After Docker is up: `pnpm dev:db` (or `docker compose up -d postgres`).
+
+### Env files
+- `.env` files are gitignored. Create them once from the examples: copy `apps/api/.env.example` → `apps/api/.env` (and the same for `staff`/`scholar`). The example values already point at the local Postgres (`DB_PORT=5433`) and a valid dev `BETTER_AUTH_SECRET`.
+
+### Running everything
+- `pnpm dev` runs all apps + Storybook in parallel. Turbo's `dev` task depends on `migrate` → `docker`, so it runs `docker compose up -d` and Drizzle migrations automatically — but only after `dockerd` is already running (see above).
+- Migrations: `pnpm db:migrate` (Drizzle). Generate with `pnpm db:generate`.
+
+### Seed / test data (non-obvious)
+- `apps/api` seed script `pnpm db:populate-dev` is **interactive** (prompts for a staff invitation email via stdin). Run it non-interactively with `echo "" | pnpm db:populate-dev` to skip the prompt. It is idempotent (upserts) and creates 30 demo scholars plus tasks/goals/announcements/requests.
+- Seeded users have **no password** — Better Auth sets passwords only at signup. To get a usable staff login you must first insert a `pending` staff `invitation` row for the email, then sign up (invitation → signup → login is the real onboarding flow; `/api/auth/sign-up/email` rejects emails without an invitation).
+
+### Lint caveat
+- CI's authoritative lint is `pnpm lint` (runs `check:skills` + `turbo run check`). The packages don't define a `check` task, so Biome linting of source is effectively driven by the root `pnpm check` (`biome check .`), and the per-app `lint` scripts use `biome check --write` to auto-fix. Running `pnpm check` on a fresh checkout reports pre-existing warnings/errors that are not from your changes.
+- `.claude/settings.json` registers a `PostToolUse` hook that runs `pnpm format` (Biome) after edits.
+
+### Tests / build
+- `pnpm test` (Jest across api/staff/scholar), `pnpm build` (Turbo, builds packages before apps). API integration/e2e are separate: `pnpm test:integration`, `pnpm test:e2e`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,26 @@ This is a Turborepo + pnpm monorepo. The standard commands in `README.md`, `CLAU
 - `apps/scholar` — Next.js scholar portal on `http://localhost:4002`.
 - `packages/ui` — Storybook on `http://localhost:6006`.
 
-Note: `README.md`/`docs` mention ports 3000/3001/3002, but the actual dev ports are **4000/4001/4002** (see `apps/*/package.json` and `apps/api/.env.example`).
+### Docker
 
-### Postgres runs in Docker (must be started manually)
-- Postgres 17.5 runs via `docker compose up -d postgres` and is published on host port **5433** (not 5432). See `docker-compose.yml`.
-- Docker is pre-installed in the VM snapshot, but `dockerd` is **not** running on boot. Start it once per session:
-  - `sudo bash -c 'nohup dockerd > /tmp/dockerd.log 2>&1 &'` then `sudo chmod 666 /var/run/docker.sock` so `docker` works without sudo (Turbo's `pnpm dev` calls `docker compose` directly).
-- After Docker is up: `pnpm dev:db` (or `docker compose up -d postgres`).
+Cursor Cloud snapshots may already have Docker installed, but `dockerd` is **not** running on boot, and some snapshots have no Docker at all. `pnpm dev` depends on `docker compose` to start Postgres, so the daemon must be up and your user must be in the `docker` group.
+
+Cloud Agents run `./scripts/_docker_install.sh` automatically from `.cursor/environment.json` (`install` bakes Docker into the Build; `start` brings `dockerd` up for the session). If Docker is not already healthy, run the same idempotent helper yourself:
+
+```bash
+./scripts/_docker_install.sh
+```
+
+That script:
+
+- exits immediately when Docker is already healthy (does not `pkill` a running daemon)
+- installs Docker CE when `dockerd` is missing
+- starts `dockerd` when it is installed but not running
+- adds your user to the `docker` group so `docker compose` works without sudo
+
+Do **not** `chmod 666 /var/run/docker.sock`. A world-writable Docker socket is root-equivalent for every process on the VM.
+
+After Docker is up: `pnpm dev:db` (or `docker compose up -d postgres`). Postgres 17.5 is published on host port **5433** (not 5432). See `docker-compose.yml`.
 
 ### Env files
 - `.env` files are gitignored. Create them once from the examples: copy `apps/api/.env.example` → `apps/api/.env` (and the same for `staff`/`scholar`). The example values already point at the local Postgres (`DB_PORT=5433`) and a valid dev `BETTER_AUTH_SECRET`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a **Turborepo monorepo** with TypeScript, containing:
 
-- **apps/api** - NestJS API server using Fastify (runs on default port)
-- **apps/staff** - Next.js staff portal application (runs on port 3001)
-- **apps/scholar** - Next.js scholar portal application (runs on port 3002)
+- **apps/api** - NestJS API server using Fastify (runs on port 4000)
+- **apps/staff** - Next.js staff portal application (runs on port 4001)
+- **apps/scholar** - Next.js scholar portal application (runs on port 4002)
 - **packages/api** - Shared NestJS resources and DTOs
 - **packages/ui** - React component library
 - **packages/eslint-config** - ESLint configurations with Prettier
@@ -64,7 +64,7 @@ pnpm test:e2e     # End-to-end tests
 
 ```bash
 cd apps/staff
-pnpm dev          # Development server (port 3001)
+pnpm dev          # Development server (port 4001)
 pnpm build        # Build for production
 pnpm test:watch   # Tests in watch mode
 pnpm test:e2e     # Playwright e2e tests
@@ -74,7 +74,7 @@ pnpm test:e2e     # Playwright e2e tests
 
 ```bash
 cd apps/scholar
-pnpm dev          # Development server (port 3002)
+pnpm dev          # Development server (port 4002)
 pnpm build        # Build for production
 pnpm test:watch   # Tests in watch mode
 pnpm test:e2e     # Playwright e2e tests

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ This monorepo uses Turborepo and these tools are set up:
 ### Apps and Packages
 
     ├── apps
-    │   ├── api                       # NestJS API server with PostgreSQL
-    │   ├── staff                     # Next.js staff portal (port 3001)
-    │   └── scholar                   # Next.js scholar portal (port 3002)
+    │   ├── api                       # NestJS API server with PostgreSQL (port 4000)
+    │   ├── staff                     # Next.js staff portal (port 4001)
+    │   └── scholar                   # Next.js scholar portal (port 4002)
     └── packages
         ├── @workspace/jest-config         # Jest configurations
         ├── @workspace/typescript-config   # TypeScript configurations

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -10,10 +10,10 @@ First, run the development server:
 pnpm run dev
 ```
 
-By default, your server will run at [http://localhost:3000](http://localhost:3000). 
+In development (`PORT=4000` in `.env.example`), your server will run at [http://localhost:4000](http://localhost:4000).
 
-- **API Documentation**: [http://localhost:3000/api](http://localhost:3000/api) (Swagger UI)
-- **Homepage**: [http://localhost:3000](http://localhost:3000) (API welcome page)
+- **API Documentation**: [http://localhost:4000/api](http://localhost:4000/api) (Swagger UI)
+- **Homepage**: [http://localhost:4000](http://localhost:4000) (API welcome page)
 
 ## Architecture
 

--- a/apps/scholar/README.md
+++ b/apps/scholar/README.md
@@ -31,7 +31,7 @@ Currently, this is a placeholder application with a simple landing page. Feature
 # From the monorepo root
 pnpm install
 
-# Start the development server (runs on port 3002)
+# Start the development server (runs on port 4002)
 cd apps/scholar
 pnpm dev
 
@@ -41,7 +41,7 @@ pnpm dev --filter=scholar
 
 ### Available Scripts
 
-- `pnpm dev` - Start development server on port 3002
+- `pnpm dev` - Start development server on port 4002
 - `pnpm build` - Build for production
 - `pnpm start` - Start production server
 - `pnpm lint` - Run linting

--- a/apps/staff/README.md
+++ b/apps/staff/README.md
@@ -10,7 +10,7 @@ First, run the development server:
 pnpm run dev
 ```
 
-Open [http://localhost:3001](http://localhost:3001) in your browser to see the application.
+Open [http://localhost:4001](http://localhost:4001) in your browser to see the application.
 
 ## Architecture
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -36,8 +36,8 @@ This is a **monorepo** (multiple projects in one repository) built with:
 ashinaga/
 ├── apps/
 │   ├── api/          # Backend API server (NestJS)
-│   ├── staff/        # Staff portal (Next.js) - Port 3001
-│   └── scholar/      # Scholar portal (Next.js) - Port 3002
+│   ├── staff/        # Staff portal (Next.js) - Port 4001
+│   └── scholar/      # Scholar portal (Next.js) - Port 4002
 ├── packages/
 │   ├── ui/           # Shared React components
 │   └── ...           # Other shared packages
@@ -254,7 +254,7 @@ This will install all packages needed for all apps and packages in the monorepo.
 2. The default values should work:
    ```env
    NEXT_PUBLIC_API_URL=http://localhost:4000
-   NEXT_PUBLIC_SCHOLAR_APP_URL=http://localhost:3002
+   NEXT_PUBLIC_SCHOLAR_APP_URL=http://localhost:4002
    ```
 
 #### Scholar App Environment Variables
@@ -335,8 +335,8 @@ pnpm dev
 
 This starts all applications:
 - **API**: http://localhost:4000 (or port specified in .env)
-- **Staff Portal**: http://localhost:3001
-- **Scholar Portal**: http://localhost:3002
+- **Staff Portal**: http://localhost:4001
+- **Scholar Portal**: http://localhost:4002
 
 **Note**: Keep this terminal open - it runs the servers in watch mode (auto-restarts on changes).
 
@@ -348,10 +348,10 @@ This starts all applications:
 2. **API Documentation**: Visit http://localhost:4000/api
    - Should show Swagger UI with API endpoints
 
-3. **Staff Portal**: Visit http://localhost:3001
+3. **Staff Portal**: Visit http://localhost:4001
    - Should load the staff portal
 
-4. **Scholar Portal**: Visit http://localhost:3002
+4. **Scholar Portal**: Visit http://localhost:4002
    - Should load the scholar portal
 
 ### Common Setup Issues
@@ -546,7 +546,7 @@ pnpm build
 #### Frontend Testing
 
 1. **Manual Testing**:
-   - Visit http://localhost:3001 (staff) or http://localhost:3002 (scholar)
+   - Visit http://localhost:4001 (staff) or http://localhost:4002 (scholar)
    - Test the UI manually
 
 2. **Run Tests**:
@@ -883,8 +883,8 @@ Before starting your first task, make sure you can:
 
 - [ ] Run `pnpm dev` and see all apps running
 - [ ] Access API docs at http://localhost:4000/api
-- [ ] Access staff portal at http://localhost:3001
-- [ ] Access scholar portal at http://localhost:3002
+- [ ] Access staff portal at http://localhost:4001
+- [ ] Access scholar portal at http://localhost:4002
 - [ ] Run `pnpm lint` without errors
 - [ ] Run `pnpm test` and see tests pass
 - [ ] Open database GUI with `pnpm db:studio`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,8 +20,9 @@ Welcome to the Ashinaga monorepo! This is a minimal, clean starting point for bu
    ```
 
 This will start:
-- **API**: [http://localhost:3000](http://localhost:3000)
-- **Web App**: [http://localhost:3001](http://localhost:3001)
+- **API**: [http://localhost:4000](http://localhost:4000)
+- **Staff Portal**: [http://localhost:4001](http://localhost:4001)
+- **Scholar Portal**: [http://localhost:4002](http://localhost:4002)
 - **Storybook**: [http://localhost:6006](http://localhost:6006)
 
 ## What's Included

--- a/scripts/_docker_install.sh
+++ b/scripts/_docker_install.sh
@@ -1,26 +1,125 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "=== Installing Docker ==="
-sudo install -m 0755 -d /etc/apt/keyrings
-curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-sudo chmod a+r /etc/apt/keyrings/docker.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-sudo apt-get install -y fuse-overlayfs iptables
+# Idempotent Docker bootstrap for Cursor Cloud VMs.
+# Safe to re-run: exits early when Docker is already healthy, does not kill a
+# running daemon, and does not make /var/run/docker.sock world-writable.
 
-echo "=== Configuring Docker daemon for fuse-overlayfs ==="
-sudo mkdir -p /etc/docker
-printf '%s\n' '{' '  "storage-driver": "fuse-overlayfs"' '}' | sudo tee /etc/docker/daemon.json > /dev/null
+DOCKERD_LOG=/tmp/dockerd.log
+DOCKERD_TIMEOUT=60
+USER_NAME="${SUDO_USER:-$USER}"
 
-sudo update-alternatives --set iptables /usr/sbin/iptables-legacy || true
-sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
+docker_info_sudo() {
+  sudo docker info >/dev/null 2>&1
+}
 
-echo "=== Starting dockerd ==="
-sudo pkill dockerd || true
-sleep 2
-sudo bash -c 'nohup dockerd > /tmp/dockerd.log 2>&1 &'
-sleep 8
-sudo docker version
+docker_info_user() {
+  docker info >/dev/null 2>&1
+}
+
+wait_for_dockerd() {
+  local elapsed=0
+  until docker_info_sudo; do
+    if (( elapsed >= DOCKERD_TIMEOUT )); then
+      echo "dockerd did not become ready within ${DOCKERD_TIMEOUT}s. Last log lines:" >&2
+      tail -n 50 "$DOCKERD_LOG" >&2 || true
+      exit 1
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+}
+
+ensure_docker_group() {
+  if [[ "$USER_NAME" == "root" ]]; then
+    return
+  fi
+  if ! getent group docker >/dev/null 2>&1; then
+    sudo groupadd docker
+  fi
+  if ! id -nG "$USER_NAME" | grep -qw docker; then
+    sudo usermod -aG docker "$USER_NAME"
+    echo "Added ${USER_NAME} to the docker group."
+  fi
+}
+
+# Group membership only applies to new login sessions. Grant this user (only)
+# rw on the live socket so `docker compose` works immediately, without
+# chmod 666 (world-writable socket == root-equivalent for every process).
+grant_current_session_socket_access() {
+  if [[ "$USER_NAME" == "root" ]]; then
+    return
+  fi
+  if docker_info_user; then
+    return
+  fi
+  if [[ ! -S /var/run/docker.sock ]]; then
+    echo "Docker socket not found at /var/run/docker.sock" >&2
+    exit 1
+  fi
+  if ! command -v setfacl >/dev/null 2>&1; then
+    sudo apt-get install -y acl
+  fi
+  sudo setfacl -m "u:${USER_NAME}:rw" /var/run/docker.sock
+}
+
+start_dockerd() {
+  if docker_info_sudo; then
+    return
+  fi
+  echo "=== Starting dockerd ==="
+  sudo bash -c "nohup dockerd > ${DOCKERD_LOG} 2>&1 &"
+  wait_for_dockerd
+}
+
+install_docker() {
+  echo "=== Installing Docker ==="
+  sudo install -m 0755 -d /etc/apt/keyrings
+  curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg |
+    sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
+  sudo chmod a+r /etc/apt/keyrings/docker.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  sudo apt-get install -y fuse-overlayfs iptables
+}
+
+ensure_daemon_json() {
+  sudo mkdir -p /etc/docker
+  if [[ -f /etc/docker/daemon.json ]]; then
+    echo "=== /etc/docker/daemon.json already exists, leaving it unchanged ==="
+    return
+  fi
+  echo "=== Writing Docker daemon.json (fuse-overlayfs) ==="
+  sudo tee /etc/docker/daemon.json >/dev/null <<'EOF'
+{
+  "storage-driver": "fuse-overlayfs"
+}
+EOF
+}
+
+if docker_info_user || docker_info_sudo; then
+  ensure_docker_group
+  grant_current_session_socket_access
+  echo "=== Docker already running ==="
+  docker version 2>/dev/null || sudo docker version
+  exit 0
+fi
+
+if ! command -v dockerd >/dev/null 2>&1; then
+  install_docker
+  ensure_daemon_json
+  sudo update-alternatives --set iptables /usr/sbin/iptables-legacy || true
+  sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
+else
+  echo "=== Docker is installed; starting the daemon ==="
+  ensure_daemon_json
+fi
+
+ensure_docker_group
+start_dockerd
+grant_current_session_socket_access
+
 echo "=== Docker ready ==="
+docker version 2>/dev/null || sudo docker version

--- a/scripts/_docker_install.sh
+++ b/scripts/_docker_install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Installing Docker ==="
+sudo install -m 0755 -d /etc/apt/keyrings
+curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo apt-get install -y fuse-overlayfs iptables
+
+echo "=== Configuring Docker daemon for fuse-overlayfs ==="
+sudo mkdir -p /etc/docker
+printf '%s\n' '{' '  "storage-driver": "fuse-overlayfs"' '}' | sudo tee /etc/docker/daemon.json > /dev/null
+
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy || true
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
+
+echo "=== Starting dockerd ==="
+sudo pkill dockerd || true
+sleep 2
+sudo bash -c 'nohup dockerd > /tmp/dockerd.log 2>&1 &'
+sleep 8
+sudo docker version
+echo "=== Docker ready ==="


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Set up and verified the full development environment for this Turborepo monorepo (API + staff + scholar + Storybook) in the Cloud VM.
- Added `AGENTS.md` with durable, non-obvious Cursor Cloud setup/run caveats (real dev ports are 4000/4001/4002, Postgres on 5433 in Docker, `dockerd` must be started per session, interactive seed script gotcha, invitation→signup→login flow, lint caveat).
- Added `scripts/_docker_install.sh`, a small idempotent helper documenting the Docker install/daemon bootstrap used for the local Postgres container.
- Registered the startup update script as `pnpm install` (dependency refresh only; Docker/system deps live in the VM snapshot).

No application/source code was modified.

## Validation Notes

- `pnpm lint`: pass (skills contract + `turbo run check`).
- `pnpm test`: pass — 3/3 Turbo tasks (API 92 tests + staff + scholar).
- `pnpm build`: pass — packages + all 3 apps built.
- `pnpm dev` (root) outcome: API on `:4000`, staff on `:4001`, scholar on `:4002`, Storybook on `:6006` all start after Postgres is up + migrations applied.
- Hello-world (end-to-end): created a staff invitation, signed up + signed in `demo.staff@example.com` via the API (`/api/auth/*`), and the authenticated `/api/scholars` returned seeded data. Then logged into the **staff portal UI** and loaded the dashboard showing 30 seeded scholars + working search.
- Any unrelated blockers (ports/services/etc.): Docker isn't running on boot — start `dockerd` per session (documented in `AGENTS.md`).

[staff_portal_login_hello_world.mp4](https://cursor.com/agents/bc-113d0b54-0995-4c7d-8de0-1fa4ca3035d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstaff_portal_login_hello_world.mp4)

[Staff dashboard overview showing 30 scholars](https://cursor.com/agents/bc-113d0b54-0995-4c7d-8de0-1fa4ca3035d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstaff_dashboard_overview.webp)

[Staff scholars list](https://cursor.com/agents/bc-113d0b54-0995-4c7d-8de0-1fa4ca3035d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstaff_scholars_list.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-113d0b54-0995-4c7d-8de0-1fa4ca3035d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-113d0b54-0995-4c7d-8de0-1fa4ca3035d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

