### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a Turborepo monorepo (`pnpm@10.15.1`, Node `>=18`) with three runtime services plus shared packages. Standard commands live in `README.md`, `CLAUDE.md`, and each package's `package.json`; this section only records non-obvious cloud/startup caveats.
+
+### Services and ports (actual dev ports)
+
+| Service | Dir | Dev command | Port |
+| --- | --- | --- | --- |
+| API (NestJS + Fastify) | `apps/api` | `pnpm dev` | 4000 (Swagger at `/api`, health at `/health`) |
+| Staff portal (Next.js) | `apps/staff` | `pnpm dev` | 4001 |
+| Scholar portal (Next.js) | `apps/scholar` | `pnpm dev` | 4002 |
+| Postgres | (docker) | `pnpm dev:db` | host 5433 → container 5432 |
+
+Note: some docs (`README.md`, `docs/getting-started.md`, `apps/api/README.md`, `CLAUDE.md`) mention ports 3000/3001/3002 — those are stale. The real ports come from the `.env` files / package scripts and are 4000/4001/4002 (Postgres on 5433).
+
+### Docker daemon must be started manually (no systemd)
+
+The VM has no systemd, so `systemctl start docker` fails. Docker (with `fuse-overlayfs` storage driver + `iptables-legacy`, and `containerd-snapshotter` disabled for Docker 29) is already installed/configured. Start the daemon once per boot in a tmux session, e.g. `sudo dockerd` (leave it running), then bring up Postgres with `pnpm dev:db` (or `docker compose up -d postgres`). The `ubuntu` user is in the `docker` group; if `docker` still reports a permission error after a fresh boot, run `sudo chmod 666 /var/run/docker.sock`.
+
+### Environment files
+
+`apps/api/.env`, `apps/staff/.env`, `apps/scholar/.env` are gitignored and are created from the committed `.env.example` files in each app. `BETTER_AUTH_SECRET` in `apps/api/.env` must be at least 32 chars. Optional integrations (Resend email, AWS S3 uploads, Microsoft SSO) are unset by default; core flows work without them (password-reset links are logged to the API console instead of emailed).
+
+### Database: migrations and seed data
+
+- Apply schema: `pnpm db:migrate` (root) → `drizzle-kit migrate` in `apps/api`. Uses individual `DB_*` vars, not a single `DATABASE_URL`.
+- Seed demo data: `cd apps/api && pnpm db:populate-dev`. This script is idempotent but **prompts on stdin** for a staff-invitation email — in a non-interactive shell pipe one in, e.g. `echo "admin@ashinaga.dev" | pnpm db:populate-dev`. It seeds 30 demo scholars plus tasks/goals/announcements/requests.
+- The Better Auth user table is named `user` (singular) and uses snake_case columns (e.g. `user_type`, `email_verified`).
+
+### Auth / how to log in
+
+Signup requires a **valid, pending invitation row** in the `invitations` table for that email (enforced by a Better Auth `signUp.before` hook). To get into the staff portal: seed an invitation for your email (the `db:populate-dev` prompt creates a staff invite), then go to `http://localhost:4001/signup` and register with that exact email and a password (min 8 chars). Passwords are not seeded; every account is created via signup. (In `NODE_ENV=test`, the invitation check is bypassed and `@ashinaga.org` emails become staff.)
+
+### Lint caveat
+
+`pnpm lint` runs `pnpm check:skills && turbo run check`, but no package defines a `check` task, so `turbo run check` executes 0 tasks and passes trivially. The real Biome lint is the root `pnpm check` (`biome check .`). As of setup it reports pre-existing errors/warnings in committed source; auto-fixable ones are handled by the Husky `pre-commit` hook (`pnpm check:fix`).
+
+### Running the apps in a headless session
+
+Root `pnpm dev` uses Turbo's `tui` UI (needs a TTY) and chains `docker` → `migrate` → `dev`. In headless cloud sessions it is more reliable to start Postgres once (`pnpm dev:db`), then run each app's `pnpm dev` in its own tmux session. NestJS (`apps/api`) and Next.js dev servers hot-reload on source changes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Sets up the Cloud Agent development environment for this monorepo and adds `AGENTS.md` documenting durable, non-obvious startup/run caveats for future agents.
- No application/source code was changed. The only tracked change is the new `AGENTS.md`; `.env` files are gitignored and were created locally from the committed `.env.example` templates.

### What was set up

- Installed workspace deps with `pnpm install` (`pnpm@10.15.1`, Node 22).
- Installed & configured Docker (no systemd → `dockerd` started manually; `fuse-overlayfs` storage driver + `iptables-legacy`, `containerd-snapshotter` disabled for Docker 29).
- Created `.env` for `apps/api`, `apps/staff`, `apps/scholar` from their `.env.example` (real 32+ char `BETTER_AUTH_SECRET`).
- Started Postgres via `pnpm dev:db`, applied migrations (`pnpm db:migrate`), and seeded demo data (`pnpm db:populate-dev`, 30 scholars).

### Services verified

| Service | Command | Port | Result |
| --- | --- | --- | --- |
| API (NestJS) | `pnpm dev` (apps/api) | 4000 | Up, `/health` + Swagger `/api` 200 |
| Staff portal | `pnpm dev` (apps/staff) | 4001 | Up, HTTP 200 |
| Scholar portal | `pnpm dev` (apps/scholar) | 4002 | Up, HTTP 200 |
| Postgres | `pnpm dev:db` | 5433 | Healthy |

### Hello-world task (end-to-end)

Registered a staff account at `http://localhost:4001/signup` (`admin@ashinaga.dev`, seeded invitation), landed on the dashboard showing "Total Scholars: 30", browsed the scholars list and a scholar detail page. Verified the account was persisted in Postgres (`user_type=staff`, `credential` account) and the invitation flipped to `accepted` — proving frontend → API → DB works.

### Update script (runs on VM startup)

`pnpm install` (minimal, idempotent dependency refresh). Docker/Postgres startup, `.env` creation, migrations, and seeding are documented in `AGENTS.md` rather than the startup script.

## Validation Notes

- `pnpm check:skills`: passes (1 skill package).
- `pnpm lint`: `turbo run check` runs 0 tasks (no package defines a `check` task) and passes; root `pnpm check` (Biome) reports pre-existing errors/warnings in committed source (not introduced here).
- `pnpm test`: 3/3 turbo test tasks pass (API: 18 suites, 74 tests).
- `pnpm dev` (per-app in headless tmux): all three apps start and serve 200.
- Unrelated blockers: docs (`README.md`, `CLAUDE.md`, `docs/getting-started.md`) list stale ports 3000/3001/3002; actual dev ports are 4000/4001/4002.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24e60fc6-6ea6-439b-a6f6-9327305a6f46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24e60fc6-6ea6-439b-a6f6-9327305a6f46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

