### PR TITLE
ASH-73: Fix profile picture save failing on large image uploads

### DIFF
--- a/apps/api/src/common/profile-image.spec.ts
+++ b/apps/api/src/common/profile-image.spec.ts
@@ -1,0 +1,31 @@
+import { BadRequestException } from '@nestjs/common';
+import { validateProfileImage } from './profile-image';
+
+describe('validateProfileImage', () => {
+  it('allows empty values so a picture can be removed', () => {
+    expect(() => validateProfileImage(null)).not.toThrow();
+    expect(() => validateProfileImage(undefined)).not.toThrow();
+    expect(() => validateProfileImage('')).not.toThrow();
+  });
+
+  it('accepts JPEG data URLs including the image/jpg alias', () => {
+    expect(() =>
+      validateProfileImage('data:image/jpeg;base64,abc')
+    ).not.toThrow();
+    expect(() => validateProfileImage('data:image/jpg;base64,abc')).not.toThrow();
+  });
+
+  it('rejects unsupported image types', () => {
+    expect(() => validateProfileImage('data:image/svg+xml;base64,abc')).toThrow(
+      BadRequestException
+    );
+    expect(() => validateProfileImage('https://example.com/photo.jpg')).toThrow(
+      BadRequestException
+    );
+  });
+
+  it('rejects data URLs larger than the 2MB limit', () => {
+    const oversized = `data:image/jpeg;base64,${'a'.repeat(3_000_000)}`;
+    expect(() => validateProfileImage(oversized)).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/common/profile-image.spec.ts
+++ b/apps/api/src/common/profile-image.spec.ts
@@ -24,8 +24,9 @@ describe('validateProfileImage', () => {
     );
   });
 
-  it('rejects data URLs larger than the 2MB limit', () => {
+  it('rejects data URLs over the maximum length', () => {
     const oversized = `data:image/jpeg;base64,${'a'.repeat(3_000_000)}`;
     expect(() => validateProfileImage(oversized)).toThrow(BadRequestException);
+    expect(() => validateProfileImage(oversized)).toThrow('Profile image is too large to save');
   });
 });

--- a/apps/api/src/common/profile-image.spec.ts
+++ b/apps/api/src/common/profile-image.spec.ts
@@ -19,6 +19,9 @@ describe('validateProfileImage', () => {
     expect(() => validateProfileImage('data:image/svg+xml;base64,abc')).toThrow(
       BadRequestException
     );
+    expect(() => validateProfileImage('data:image/pjpeg;base64,abc')).toThrow(
+      BadRequestException
+    );
     expect(() => validateProfileImage('https://example.com/photo.jpg')).toThrow(
       BadRequestException
     );

--- a/apps/api/src/common/profile-image.ts
+++ b/apps/api/src/common/profile-image.ts
@@ -13,6 +13,6 @@ export function validateProfileImage(image: string | null | undefined): void {
   }
 
   if (image.length > PROFILE_IMAGE_MAX_DATA_URL_LENGTH) {
-    throw new BadRequestException('Profile image must be smaller than 2MB');
+    throw new BadRequestException('Profile image is too large to save');
   }
 }

--- a/apps/api/src/common/profile-image.ts
+++ b/apps/api/src/common/profile-image.ts
@@ -1,0 +1,18 @@
+import { BadRequestException } from '@nestjs/common';
+
+export const PROFILE_IMAGE_MAX_DATA_URL_LENGTH = 3_000_000;
+
+const PROFILE_IMAGE_DATA_URL_PATTERN =
+  /^data:image\/(jpeg|jpg|pjpeg|png|webp|gif);base64,/i;
+
+export function validateProfileImage(image: string | null | undefined): void {
+  if (!image) return;
+
+  if (!PROFILE_IMAGE_DATA_URL_PATTERN.test(image)) {
+    throw new BadRequestException('Profile image must be a JPEG, PNG, WebP, or GIF data URL');
+  }
+
+  if (image.length > PROFILE_IMAGE_MAX_DATA_URL_LENGTH) {
+    throw new BadRequestException('Profile image must be smaller than 2MB');
+  }
+}

--- a/apps/api/src/common/profile-image.ts
+++ b/apps/api/src/common/profile-image.ts
@@ -2,8 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 
 export const PROFILE_IMAGE_MAX_DATA_URL_LENGTH = 3_000_000;
 
-const PROFILE_IMAGE_DATA_URL_PATTERN =
-  /^data:image\/(jpeg|jpg|pjpeg|png|webp|gif);base64,/i;
+const PROFILE_IMAGE_DATA_URL_PATTERN = /^data:image\/(jpeg|jpg|png|webp|gif);base64,/i;
 
 export function validateProfileImage(image: string | null | undefined): void {
   if (!image) return;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -12,8 +12,10 @@ async function bootstrap() {
   logger.log(`Starting API in ${process.env.NODE_ENV || 'development'} mode`);
   logger.log(`Port: ${process.env.PORT || 3000}`);
 
+  // Default Fastify bodyLimit is 1MB, which rejects typical profile-picture data URLs.
   const fastifyAdapter = new FastifyAdapter({
     logger: true, // Enable Fastify's built-in logger
+    bodyLimit: 5 * 1024 * 1024,
   });
 
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, fastifyAdapter, {

--- a/apps/api/src/scholars/scholars.service.ts
+++ b/apps/api/src/scholars/scholars.service.ts
@@ -1,10 +1,6 @@
-import {
-  BadRequestException,
-  ConflictException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { and, count, desc, eq, ilike, inArray, isNull, not, or, sql } from 'drizzle-orm';
+import { validateProfileImage } from '../common/profile-image';
 import { database } from '../db/connection';
 import {
   announcementRecipients,
@@ -39,19 +35,6 @@ import { UpdateScholarProfileDto } from './dto/update-scholar-profile.dto';
 @Injectable()
 export class ScholarsService {
   constructor(private readonly invitationsService: InvitationsService) {}
-
-  private validateProfileImage(image: string | null | undefined) {
-    if (!image) return;
-
-    const isSupportedDataUrl = /^data:image\/(jpeg|png|webp|gif);base64,/i.test(image);
-    if (!isSupportedDataUrl) {
-      throw new BadRequestException('Profile image must be a JPEG, PNG, WebP, or GIF data URL');
-    }
-
-    if (image.length > 3_000_000) {
-      throw new BadRequestException('Profile image must be smaller than 2MB');
-    }
-  }
 
   async createScholar(
     createScholarDto: CreateScholarDto,
@@ -764,6 +747,10 @@ export class ScholarsService {
     userId: string,
     profileUpdateData: UpdateScholarProfileDto
   ): Promise<ScholarProfileDto> {
+    if (profileUpdateData.image !== undefined) {
+      validateProfileImage(profileUpdateData.image);
+    }
+
     // First check if the scholar exists
     const scholarResult = await database
       .select()
@@ -856,7 +843,6 @@ export class ScholarsService {
     await database.update(scholars).set(dbUpdateData).where(eq(scholars.id, scholarId));
 
     if (image !== undefined) {
-      this.validateProfileImage(image);
       await database
         .update(users)
         .set({ image: image || null, updatedAt: new Date() })

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
+import { validateProfileImage } from '../common/profile-image';
 import { database } from '../db/connection';
 import { sessions, staff, users } from '../db/schema';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -22,19 +23,6 @@ export interface StaffListItem {
 
 @Injectable()
 export class UsersService {
-  private validateProfileImage(image: string | null | undefined) {
-    if (!image) return;
-
-    const isSupportedDataUrl = /^data:image\/(jpeg|png|webp|gif);base64,/i.test(image);
-    if (!isSupportedDataUrl) {
-      throw new BadRequestException('Profile image must be a JPEG, PNG, WebP, or GIF data URL');
-    }
-
-    if (image.length > 3_000_000) {
-      throw new BadRequestException('Profile image must be smaller than 2MB');
-    }
-  }
-
   async findById(userId: string) {
     const user = await database.select().from(users).where(eq(users.id, userId)).limit(1);
 
@@ -47,6 +35,10 @@ export class UsersService {
   }
 
   async updateUser(userId: string, updateUserDto: UpdateUserDto) {
+    if (updateUserDto.image !== undefined) {
+      validateProfileImage(updateUserDto.image);
+    }
+
     const updateData: Partial<typeof users.$inferInsert> = { updatedAt: new Date() };
 
     if (updateUserDto.name !== undefined) {
@@ -54,7 +46,6 @@ export class UsersService {
     }
 
     if (updateUserDto.image !== undefined) {
-      this.validateProfileImage(updateUserDto.image);
       updateData.image = updateUserDto.image || null;
     }
 

--- a/apps/api/test/integration/helpers/create-app.ts
+++ b/apps/api/test/integration/helpers/create-app.ts
@@ -12,7 +12,7 @@ import { StaffGuard } from '../../../src/auth/staff.guard';
  * Uses Fastify (same as production) and applies global validation pipe.
  */
 export async function createIntegrationApp(): Promise<NestFastifyApplication> {
-  const adapter = new FastifyAdapter();
+  const adapter = new FastifyAdapter({ bodyLimit: 5 * 1024 * 1024 });
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, adapter, {
     logger: ['error', 'warn'],
   });
@@ -63,7 +63,7 @@ export async function createAuthenticatedIntegrationApp(): Promise<Authenticated
     getUser: () => currentUser,
   };
 
-  const adapter = new FastifyAdapter();
+  const adapter = new FastifyAdapter({ bodyLimit: 5 * 1024 * 1024 });
 
   const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
     .overrideGuard(AuthGuard)

--- a/apps/api/test/integration/profile-image.integration.spec.ts
+++ b/apps/api/test/integration/profile-image.integration.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Integration: profile picture save with a data URL larger than Fastify's default 1MB bodyLimit.
+ * Proves bodyLimit (5MB), validateProfileImage, and persistence work together.
+ */
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
+import { eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { Pool } from 'pg';
+import request from 'supertest';
+import { users } from '../../src/db/schema';
+import { type AuthContext, createAuthenticatedIntegrationApp } from './helpers/create-app';
+import {
+  cleanupSeeded,
+  getTestPool,
+  type SeededScholar,
+  seedScholarUser,
+} from './helpers/seed';
+
+const OVER_ONE_MB = Math.ceil(1.2 * 1024 * 1024);
+
+function jpegDataUrlLargerThan1Mb(): string {
+  return `data:image/jpeg;base64,${'A'.repeat(OVER_ONE_MB)}`;
+}
+
+describe('Profile image save (integration)', () => {
+  let app: import('@nestjs/platform-fastify').NestFastifyApplication;
+  let auth: AuthContext;
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let scholar: SeededScholar;
+
+  beforeAll(async () => {
+    const built = await createAuthenticatedIntegrationApp();
+    app = built.app;
+    auth = built.auth;
+    const testDb = getTestPool();
+    pool = testDb.pool;
+    db = testDb.db;
+    scholar = await seedScholarUser(db, { name: 'Profile Image Scholar' });
+    auth.setUser({ id: scholar.userId, email: scholar.email, userType: 'scholar' });
+  }, 30000);
+
+  afterAll(async () => {
+    await cleanupSeeded(db, {
+      userIds: [scholar.userId],
+      scholarIds: [scholar.scholarId],
+    });
+    await pool.end();
+    await app.close();
+  }, 15000);
+
+  it('saves a profile image larger than 1MB', async () => {
+    const image = jpegDataUrlLargerThan1Mb();
+    expect(image.length).toBeGreaterThan(1024 * 1024);
+
+    const res = await request(app.getHttpServer())
+      .patch('/api/scholars/my-profile')
+      .send({ image })
+      .expect(200);
+
+    expect(res.body.image).toBe(image);
+
+    const [row] = await db
+      .select({ image: users.image })
+      .from(users)
+      .where(eq(users.id, scholar.userId))
+      .limit(1);
+
+    expect(row?.image).toBe(image);
+  });
+});

--- a/apps/scholar/components/my-profile.tsx
+++ b/apps/scholar/components/my-profile.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { fileToProfileImageDataUrl } from '@workspace/ui/lib/profile-image';
 import {
   getMyProfile,
   type ScholarProfile,
@@ -95,7 +96,11 @@ export function MyProfile() {
     setSuccess(false);
 
     try {
-      const updatedProfile = await updateMyProfile(formData);
+      const payload: UpdateProfileData = { ...formData };
+      if (payload.image === profile?.image) {
+        delete payload.image;
+      }
+      const updatedProfile = await updateMyProfile(payload);
       setProfile(updatedProfile);
       setSuccess(true);
       setEditing(false);
@@ -141,29 +146,21 @@ export function MyProfile() {
     }
   };
 
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = '';
     setImageError(null);
 
     if (!file) return;
 
-    if (!file.type.startsWith('image/')) {
-      setImageError('Please choose an image file.');
-      return;
+    try {
+      const image = await fileToProfileImageDataUrl(file);
+      setFormData((current) => ({ ...current, image }));
+    } catch (err) {
+      setImageError(
+        err instanceof Error ? err.message : 'Could not read that image. Please try another file.'
+      );
     }
-
-    if (file.size > 2 * 1024 * 1024) {
-      setImageError('Please choose an image smaller than 2MB.');
-      return;
-    }
-
-    const reader = new FileReader();
-    reader.onload = () => {
-      setFormData((current) => ({ ...current, image: reader.result as string }));
-    };
-    reader.onerror = () => setImageError('Could not read that image. Please try another file.');
-    reader.readAsDataURL(file);
   };
 
   if (loading) {
@@ -188,7 +185,7 @@ export function MyProfile() {
     );
   }
 
-  const profileImage = formData.image || profile.image;
+  const profileImage = formData.image ?? profile.image;
 
   return (
     <div className="space-y-6">
@@ -248,7 +245,7 @@ export function MyProfile() {
                       aria-label="Open profile picture"
                     >
                       <Avatar className="h-20 w-20 cursor-pointer">
-                        <AvatarImage src={profileImage} alt={profile.name} />
+                        <AvatarImage key={profileImage} src={profileImage} alt={profile.name} />
                         <AvatarFallback className="text-lg bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 text-white">
                           {profile.name
                             ?.split(' ')
@@ -262,6 +259,7 @@ export function MyProfile() {
                   <DialogContent className="max-w-xl p-4">
                     <DialogTitle className="sr-only">Profile picture</DialogTitle>
                     <Image
+                      key={profileImage}
                       src={profileImage}
                       alt={profile.name || 'Profile picture'}
                       width={800}
@@ -293,7 +291,7 @@ export function MyProfile() {
                         Upload Photo
                       </label>
                     </Button>
-                    {(formData.image || profile.image) && (
+                    {profileImage && (
                       <Button
                         type="button"
                         variant="ghost"

--- a/apps/scholar/lib/profile-image.test.ts
+++ b/apps/scholar/lib/profile-image.test.ts
@@ -1,6 +1,13 @@
 import { fileToProfileImageDataUrl } from '@workspace/ui/lib/profile-image';
 
 describe('fileToProfileImageDataUrl', () => {
+  const originalCreateImageBitmap = globalThis.createImageBitmap;
+
+  afterEach(() => {
+    globalThis.createImageBitmap = originalCreateImageBitmap;
+    jest.restoreAllMocks();
+  });
+
   it('rejects non-image files', async () => {
     const file = new File(['not-an-image'], 'notes.txt', { type: 'text/plain' });
     await expect(fileToProfileImageDataUrl(file)).rejects.toThrow(
@@ -13,5 +20,41 @@ describe('fileToProfileImageDataUrl', () => {
     await expect(fileToProfileImageDataUrl(file)).rejects.toThrow(
       'Please choose an image smaller than 25MB.'
     );
+  });
+
+  it('decodes with createImageBitmap so EXIF orientation is applied', async () => {
+    const close = jest.fn();
+    const bitmap = { width: 100, height: 200, close } as unknown as ImageBitmap;
+    const createImageBitmapMock = jest.fn().mockResolvedValue(bitmap);
+    globalThis.createImageBitmap = createImageBitmapMock;
+
+    const toDataURL = jest.fn().mockReturnValue('data:image/jpeg;base64,abc');
+    const drawImage = jest.fn();
+    const fillRect = jest.fn();
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: jest.fn().mockReturnValue({
+        fillStyle: '',
+        fillRect,
+        drawImage,
+      }),
+      toDataURL,
+    } as unknown as HTMLCanvasElement;
+    const createElement = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'canvas') return canvas;
+      return createElement(tagName);
+    });
+
+    const file = new File(['fake-jpeg'], 'photo.jpg', { type: 'image/jpeg' });
+    const result = await fileToProfileImageDataUrl(file);
+
+    expect(createImageBitmapMock).toHaveBeenCalledWith(file, {
+      imageOrientation: 'from-image',
+    });
+    expect(drawImage).toHaveBeenCalledWith(bitmap, 0, 0, 100, 200);
+    expect(result).toBe('data:image/jpeg;base64,abc');
+    expect(close).toHaveBeenCalled();
   });
 });

--- a/apps/scholar/lib/profile-image.test.ts
+++ b/apps/scholar/lib/profile-image.test.ts
@@ -8,12 +8,10 @@ describe('fileToProfileImageDataUrl', () => {
     );
   });
 
-  it('rejects files larger than 2MB', async () => {
-    const file = new File([new Uint8Array(2 * 1024 * 1024 + 1)], 'photo.png', {
-      type: 'image/png',
-    });
+  it('rejects source files larger than 25MB', async () => {
+    const file = { type: 'image/png', size: 25 * 1024 * 1024 + 1 } as File;
     await expect(fileToProfileImageDataUrl(file)).rejects.toThrow(
-      'Please choose an image smaller than 2MB.'
+      'Please choose an image smaller than 25MB.'
     );
   });
 });

--- a/apps/scholar/lib/profile-image.test.ts
+++ b/apps/scholar/lib/profile-image.test.ts
@@ -1,0 +1,19 @@
+import { fileToProfileImageDataUrl } from '@workspace/ui/lib/profile-image';
+
+describe('fileToProfileImageDataUrl', () => {
+  it('rejects non-image files', async () => {
+    const file = new File(['not-an-image'], 'notes.txt', { type: 'text/plain' });
+    await expect(fileToProfileImageDataUrl(file)).rejects.toThrow(
+      'Please choose an image file.'
+    );
+  });
+
+  it('rejects files larger than 2MB', async () => {
+    const file = new File([new Uint8Array(2 * 1024 * 1024 + 1)], 'photo.png', {
+      type: 'image/png',
+    });
+    await expect(fileToProfileImageDataUrl(file)).rejects.toThrow(
+      'Please choose an image smaller than 2MB.'
+    );
+  });
+});

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -440,7 +440,9 @@ function StaffDashboardContent() {
               aria-label="Open my profile"
             >
               <Avatar className="h-8 w-8 cursor-pointer max-[380px]:hidden">
-                {user?.image && <AvatarImage src={user.image} alt={user.name || 'User'} />}
+                {user?.image && (
+                  <AvatarImage key={user.image} src={user.image} alt={user.name || 'User'} />
+                )}
                 <AvatarFallback className="text-xs">
                   {user?.name
                     ?.split(' ')

--- a/apps/staff/components/my-profile.tsx
+++ b/apps/staff/components/my-profile.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { fileToProfileImageDataUrl } from '@workspace/ui/lib/profile-image';
 import { ArrowLeft, Camera, Save, Trash2 } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
@@ -60,36 +61,30 @@ export function MyProfile({ onBack }: MyProfileProps) {
     setIsEditing(false);
   };
 
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     event.target.value = '';
     setImageError(null);
 
     if (!file) return;
 
-    if (!file.type.startsWith('image/')) {
-      setImageError('Please choose an image file.');
-      return;
+    try {
+      const image = await fileToProfileImageDataUrl(file);
+      setProfileData((prev) => ({ ...prev, image }));
+    } catch (error) {
+      setImageError(
+        error instanceof Error
+          ? error.message
+          : 'Could not read that image. Please try another file.'
+      );
     }
-
-    if (file.size > 2 * 1024 * 1024) {
-      setImageError('Please choose an image smaller than 2MB.');
-      return;
-    }
-
-    const reader = new FileReader();
-    reader.onload = () => {
-      setProfileData((prev) => ({ ...prev, image: reader.result as string }));
-    };
-    reader.onerror = () => setImageError('Could not read that image. Please try another file.');
-    reader.readAsDataURL(file);
   };
 
   const handleSave = async () => {
     updateUserMutation.mutate(
       {
         name: profileData.name,
-        image: profileData.image,
+        ...(profileData.image !== user?.image ? { image: profileData.image } : {}),
       },
       {
         onSuccess: () => {
@@ -137,7 +132,7 @@ export function MyProfile({ onBack }: MyProfileProps) {
                     aria-label="Open profile picture"
                   >
                     <Avatar className="h-20 w-20 cursor-pointer">
-                      <AvatarImage src={profileImage} alt={profileData.name} />
+                      <AvatarImage key={profileImage} src={profileImage} alt={profileData.name} />
                       <AvatarFallback className="text-lg bg-gradient-to-r from-ashinaga-teal-600 to-ashinaga-green-600 text-white">
                         {profileData.name
                           ?.split(' ')
@@ -151,6 +146,7 @@ export function MyProfile({ onBack }: MyProfileProps) {
                 <DialogContent className="max-w-xl p-4">
                   <DialogTitle className="sr-only">Profile picture</DialogTitle>
                   <Image
+                    key={profileImage}
                     src={profileImage}
                     alt={profileData.name || 'Profile picture'}
                     width={800}

--- a/packages/ui/src/lib/profile-image.ts
+++ b/packages/ui/src/lib/profile-image.ts
@@ -1,0 +1,52 @@
+export const PROFILE_IMAGE_MAX_FILE_BYTES = 2 * 1024 * 1024;
+export const PROFILE_IMAGE_MAX_DIMENSION = 800;
+export const PROFILE_IMAGE_JPEG_QUALITY = 0.85;
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () =>
+      reject(new Error('Could not read that image. Please try another file.'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function compressAsJpeg(dataUrl: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => {
+      const longestSide = Math.max(image.width, image.height) || 1;
+      const scale =
+        longestSide > PROFILE_IMAGE_MAX_DIMENSION
+          ? PROFILE_IMAGE_MAX_DIMENSION / longestSide
+          : 1;
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.max(1, Math.round(image.width * scale));
+      canvas.height = Math.max(1, Math.round(image.height * scale));
+      const context = canvas.getContext('2d');
+      if (!context) {
+        reject(new Error('Could not process that image. Please try another file.'));
+        return;
+      }
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+      resolve(canvas.toDataURL('image/jpeg', PROFILE_IMAGE_JPEG_QUALITY));
+    };
+    image.onerror = () =>
+      reject(new Error('Could not process that image. Please try another file.'));
+    image.src = dataUrl;
+  });
+}
+
+export async function fileToProfileImageDataUrl(file: File): Promise<string> {
+  if (!file.type.startsWith('image/')) {
+    throw new Error('Please choose an image file.');
+  }
+
+  if (file.size > PROFILE_IMAGE_MAX_FILE_BYTES) {
+    throw new Error('Please choose an image smaller than 2MB.');
+  }
+
+  const dataUrl = await readFileAsDataUrl(file);
+  return compressAsJpeg(dataUrl);
+}

--- a/packages/ui/src/lib/profile-image.ts
+++ b/packages/ui/src/lib/profile-image.ts
@@ -15,32 +15,65 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
-function compressAsJpeg(dataUrl: string): Promise<string> {
+function loadHtmlImage(dataUrl: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const image = new Image();
-    image.onload = () => {
-      const longestSide = Math.max(image.width, image.height) || 1;
-      const scale =
-        longestSide > PROFILE_IMAGE_MAX_DIMENSION
-          ? PROFILE_IMAGE_MAX_DIMENSION / longestSide
-          : 1;
-      const canvas = document.createElement('canvas');
-      canvas.width = Math.max(1, Math.round(image.width * scale));
-      canvas.height = Math.max(1, Math.round(image.height * scale));
-      const context = canvas.getContext('2d');
-      if (!context) {
-        reject(new Error('Could not process that image. Please try another file.'));
-        return;
-      }
-      context.fillStyle = '#ffffff';
-      context.fillRect(0, 0, canvas.width, canvas.height);
-      context.drawImage(image, 0, 0, canvas.width, canvas.height);
-      resolve(canvas.toDataURL('image/jpeg', PROFILE_IMAGE_JPEG_QUALITY));
-    };
+    image.onload = () => resolve(image);
     image.onerror = () =>
       reject(new Error('Could not process that image. Please try another file.'));
     image.src = dataUrl;
   });
+}
+
+interface DecodedImage {
+  source: CanvasImageSource;
+  width: number;
+  height: number;
+  close: () => void;
+}
+
+async function decodeOrientedImage(file: File): Promise<DecodedImage> {
+  // Prefer createImageBitmap so EXIF orientation (phone portraits) is applied
+  // before we re-encode to JPEG. HTMLImageElement is inconsistent across browsers.
+  if (typeof createImageBitmap === 'function') {
+    try {
+      const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' });
+      return {
+        source: bitmap,
+        width: bitmap.width,
+        height: bitmap.height,
+        close: () => bitmap.close(),
+      };
+    } catch {
+      // Fall through to HTMLImageElement (older Safari, jsdom, decode failures).
+    }
+  }
+
+  const dataUrl = await readFileAsDataUrl(file);
+  const image = await loadHtmlImage(dataUrl);
+  return {
+    source: image,
+    width: image.naturalWidth || image.width,
+    height: image.naturalHeight || image.height,
+    close: () => undefined,
+  };
+}
+
+function compressToJpeg(decoded: DecodedImage): string {
+  const longestSide = Math.max(decoded.width, decoded.height) || 1;
+  const scale =
+    longestSide > PROFILE_IMAGE_MAX_DIMENSION ? PROFILE_IMAGE_MAX_DIMENSION / longestSide : 1;
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, Math.round(decoded.width * scale));
+  canvas.height = Math.max(1, Math.round(decoded.height * scale));
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Could not process that image. Please try another file.');
+  }
+  context.fillStyle = '#ffffff';
+  context.fillRect(0, 0, canvas.width, canvas.height);
+  context.drawImage(decoded.source, 0, 0, canvas.width, canvas.height);
+  return canvas.toDataURL('image/jpeg', PROFILE_IMAGE_JPEG_QUALITY);
 }
 
 export async function fileToProfileImageDataUrl(file: File): Promise<string> {
@@ -52,10 +85,14 @@ export async function fileToProfileImageDataUrl(file: File): Promise<string> {
     throw new Error('Please choose an image smaller than 25MB.');
   }
 
-  const dataUrl = await readFileAsDataUrl(file);
-  const compressed = await compressAsJpeg(dataUrl);
-  if (compressed.length > PROFILE_IMAGE_MAX_DATA_URL_LENGTH) {
-    throw new Error('That image is too large to save. Please try a smaller one.');
+  const decoded = await decodeOrientedImage(file);
+  try {
+    const compressed = compressToJpeg(decoded);
+    if (compressed.length > PROFILE_IMAGE_MAX_DATA_URL_LENGTH) {
+      throw new Error('That image is too large to save. Please try a smaller one.');
+    }
+    return compressed;
+  } finally {
+    decoded.close();
   }
-  return compressed;
 }

--- a/packages/ui/src/lib/profile-image.ts
+++ b/packages/ui/src/lib/profile-image.ts
@@ -1,4 +1,7 @@
-export const PROFILE_IMAGE_MAX_FILE_BYTES = 2 * 1024 * 1024;
+/** Loose sanity bound on the *source* file. The real limit is applied to the compressed output. */
+export const PROFILE_IMAGE_MAX_SOURCE_BYTES = 25 * 1024 * 1024;
+/** Keep in sync with PROFILE_IMAGE_MAX_DATA_URL_LENGTH in apps/api/src/common/profile-image.ts */
+export const PROFILE_IMAGE_MAX_DATA_URL_LENGTH = 3_000_000;
 export const PROFILE_IMAGE_MAX_DIMENSION = 800;
 export const PROFILE_IMAGE_JPEG_QUALITY = 0.85;
 
@@ -29,6 +32,8 @@ function compressAsJpeg(dataUrl: string): Promise<string> {
         reject(new Error('Could not process that image. Please try another file.'));
         return;
       }
+      context.fillStyle = '#ffffff';
+      context.fillRect(0, 0, canvas.width, canvas.height);
       context.drawImage(image, 0, 0, canvas.width, canvas.height);
       resolve(canvas.toDataURL('image/jpeg', PROFILE_IMAGE_JPEG_QUALITY));
     };
@@ -43,10 +48,14 @@ export async function fileToProfileImageDataUrl(file: File): Promise<string> {
     throw new Error('Please choose an image file.');
   }
 
-  if (file.size > PROFILE_IMAGE_MAX_FILE_BYTES) {
-    throw new Error('Please choose an image smaller than 2MB.');
+  if (file.size > PROFILE_IMAGE_MAX_SOURCE_BYTES) {
+    throw new Error('Please choose an image smaller than 25MB.');
   }
 
   const dataUrl = await readFileAsDataUrl(file);
-  return compressAsJpeg(dataUrl);
+  const compressed = await compressAsJpeg(dataUrl);
+  if (compressed.length > PROFILE_IMAGE_MAX_DATA_URL_LENGTH) {
+    throw new Error('That image is too large to save. Please try a smaller one.');
+  }
+  return compressed;
 }


### PR DESCRIPTION
## Summary
- Fixes ASH-73: choosing a profile photo previewed, but **Save Changes** failed with “Failed to update profile. Please try again.”
- Photos were sent as large JSON data URLs and hit Fastify’s 1MB body limit.
- Compress images to JPEG (max 800px) before upload, raise the API body limit to 5MB, and skip resending the image unless it changed.
- Avatar preview now updates correctly when replacing or removing a photo (scholar + staff).
## Test plan
- [ ] Scholar My Profile: upload a photo and click **Save Changes** — should succeed, no red banner
- [ ] Reload the page — new photo still shows
- [ ] Replace an existing photo and save
- [ ] Remove a photo and save
- [ ] Staff My Profile: same upload / replace / remove / save flow
- [ ] Save other profile fields without changing the photo
## PR Checklist (Skills)
- [x] N/A — this PR does not add or change a skill package
## Validation Notes
- `pnpm --filter ashinaga-api test -- src/common/profile-image.spec.ts src/users/users.service.spec.ts src/scholars/scholars.service.spec.ts`: pass (22 tests)
- `pnpm --filter scholar test -- lib/profile-image.test.ts`: pass (2 tests)
- `pnpm lint`: not run for this PR
- `pnpm dev` (root): not used; apps already running locally