### PR TITLE
ASH-101: Annual Review QA copy and fold-away

### DIFF
--- a/apps/scholar/__mocks__/lucide-react.js
+++ b/apps/scholar/__mocks__/lucide-react.js
@@ -13,8 +13,7 @@ const createMockIcon = (name) => {
   return MockIcon;
 };
 
-// Export commonly used icons
-module.exports = {
+const icons = {
   AlertCircle: createMockIcon('AlertCircle'),
   ArrowRight: createMockIcon('ArrowRight'),
   Bell: createMockIcon('Bell'),
@@ -43,3 +42,16 @@ module.exports = {
   Users: createMockIcon('Users'),
   X: createMockIcon('X'),
 };
+
+module.exports = new Proxy(icons, {
+  get(target, prop) {
+    if (prop in target) {
+      return target[prop];
+    }
+    if (typeof prop === 'string' && prop !== '__esModule') {
+      target[prop] = createMockIcon(prop);
+      return target[prop];
+    }
+    return undefined;
+  },
+});

--- a/apps/scholar/__mocks__/lucide-react.js
+++ b/apps/scholar/__mocks__/lucide-react.js
@@ -48,7 +48,7 @@ module.exports = new Proxy(icons, {
     if (prop in target) {
       return target[prop];
     }
-    if (typeof prop === 'string' && prop !== '__esModule') {
+    if (typeof prop === 'string' && !['__esModule', 'then', 'default'].includes(prop)) {
       target[prop] = createMockIcon(prop);
       return target[prop];
     }

--- a/apps/scholar/components/__tests__/my-annual-review.test.tsx
+++ b/apps/scholar/components/__tests__/my-annual-review.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { AnnualUpdate } from '../../lib/api/annual-updates';
 import { MyAnnualReview } from '../my-annual-review';
 
@@ -109,7 +109,34 @@ describe('MyAnnualReview', () => {
     });
 
     expect(screen.queryByText('Year Overview')).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Continue editing' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'Continue editing' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save Draft' })).not.toBeInTheDocument();
+  });
+
+  it('dismisses the draft saved message after a few seconds', async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+
+    try {
+      render(<MyAnnualReview />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Save Draft' })).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save Draft' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Draft saved.')).toBeInTheDocument();
+      });
+
+      act(() => {
+        jest.advanceTimersByTime(4000);
+      });
+
+      expect(screen.queryByText('Draft saved.')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('shows a single submitted confirmation and keeps the form folded', async () => {
@@ -130,6 +157,13 @@ describe('MyAnnualReview', () => {
 
     expect(screen.queryByText('Annual review submitted.')).not.toBeInTheDocument();
     expect(screen.queryByText('Year Overview')).not.toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'View responses' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: 'View responses' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Hide responses' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'View responses' }));
+
+    expect(screen.getByText('Year Overview')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide responses' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'View responses' })).not.toBeInTheDocument();
   });
 });

--- a/apps/scholar/components/__tests__/my-annual-review.test.tsx
+++ b/apps/scholar/components/__tests__/my-annual-review.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { AnnualUpdate } from '../../lib/api/annual-updates';
+import { MyAnnualReview } from '../my-annual-review';
+
+const mockGetMyAnnualUpdate = jest.fn();
+const mockGetMyDraftAnnualUpdate = jest.fn();
+const mockSaveAnnualUpdateDraft = jest.fn();
+const mockSubmitAnnualUpdate = jest.fn();
+
+jest.mock('../../lib/api/annual-updates', () => ({
+  getMyAnnualUpdate: (...args: unknown[]) => mockGetMyAnnualUpdate(...args),
+  getMyDraftAnnualUpdate: (...args: unknown[]) => mockGetMyDraftAnnualUpdate(...args),
+  saveAnnualUpdateDraft: (...args: unknown[]) => mockSaveAnnualUpdateDraft(...args),
+  submitAnnualUpdate: (...args: unknown[]) => mockSubmitAnnualUpdate(...args),
+}));
+
+function createAnnualUpdate(overrides: Partial<AnnualUpdate> = {}): AnnualUpdate {
+  return {
+    id: 'review-1',
+    scholarId: 'scholar-1',
+    academicYear: '2026/27',
+    status: 'draft',
+    highlights: 'A highlight',
+    partTimeJobs: null,
+    extracurriculars: null,
+    leadershipRolesDescription: null,
+    leadershipRolesCount: 2,
+    payItForwardDescription: null,
+    payItForwardCount: null,
+    subSaharanAfricaActivitiesDescription: null,
+    subSaharanAfricaActivitiesCount: null,
+    independentInternshipsCount: null,
+    internshipsInAfricaSummary: null,
+    internshipsElsewhereSummary: null,
+    completedAshinagaAfricaInternship: null,
+    academicYearAverageClassification: null,
+    academicYearWeightedGrade: null,
+    submittedAt: null,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('MyAnnualReview', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.scrollTo = jest.fn();
+    mockGetMyAnnualUpdate.mockResolvedValue(null);
+    mockGetMyDraftAnnualUpdate.mockResolvedValue(null);
+    mockSaveAnnualUpdateDraft.mockImplementation(async () =>
+      createAnnualUpdate({ status: 'draft' })
+    );
+  });
+
+  it('uses the requested copy and puts count questions before descriptions', async () => {
+    render(<MyAnnualReview />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Leadership and Impact')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        'This review is for the academic year shown below. Share important moments you would like Ashinaga to know about.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Summarise your leadership roles and the ways you have passed kindness forward this year.'
+      )
+    ).toBeInTheDocument();
+
+    const leadershipCount = screen.getByLabelText(
+      /How many leadership roles have you held this year/i
+    );
+    const leadershipDescription = screen.getByLabelText(/Leadership roles description/i);
+    expect(
+      leadershipCount.compareDocumentPosition(leadershipDescription) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    const payItForwardCount = screen.getByLabelText(
+      /How many pay-it-forward activities have you taken part in this year/i
+    );
+    const payItForwardDescription = screen.getByLabelText(
+      /How have you paid it forward this year/i
+    );
+    expect(
+      payItForwardCount.compareDocumentPosition(payItForwardDescription) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    expect(screen.getAllByPlaceholderText('2').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('(Enter a number)').length).toBeGreaterThan(0);
+  });
+
+  it('folds the form after a draft is saved', async () => {
+    render(<MyAnnualReview />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Draft' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Draft' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Draft saved.')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Year Overview')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Continue editing' }).length).toBeGreaterThan(0);
+  });
+
+  it('shows a single submitted confirmation and keeps the form folded', async () => {
+    mockGetMyAnnualUpdate.mockResolvedValue(
+      createAnnualUpdate({
+        status: 'submitted',
+        submittedAt: '2026-08-20T00:00:00.000Z',
+      })
+    );
+
+    render(<MyAnnualReview />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Your annual review has been submitted and can no longer be edited.')
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Annual review submitted.')).not.toBeInTheDocument();
+    expect(screen.queryByText('Year Overview')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'View responses' }).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/scholar/components/__tests__/my-annual-review.test.tsx
+++ b/apps/scholar/components/__tests__/my-annual-review.test.tsx
@@ -91,8 +91,27 @@ describe('MyAnnualReview', () => {
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
 
-    expect(screen.getAllByPlaceholderText('2').length).toBeGreaterThan(0);
+    expect(screen.getAllByPlaceholderText('e.g. 2').length).toBeGreaterThan(0);
     expect(screen.getAllByText('(Enter a number)').length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/How many pay-it-forward activities have you taken part in this year/)
+        .textContent
+    ).not.toContain('(Enter a number)');
+  });
+
+  it('loads an existing draft folded', async () => {
+    mockGetMyDraftAnnualUpdate.mockResolvedValue(createAnnualUpdate({ status: 'draft' }));
+
+    render(<MyAnnualReview />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Continue editing' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Year Overview')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Your draft is saved. Continue editing whenever you are ready.')
+    ).toBeInTheDocument();
   });
 
   it('folds the form after a draft is saved', async () => {

--- a/apps/scholar/components/my-annual-review.tsx
+++ b/apps/scholar/components/my-annual-review.tsx
@@ -5,6 +5,8 @@ import {
   BookOpen,
   BriefcaseBusiness,
   CheckCircle,
+  ChevronDown,
+  ChevronUp,
   ClipboardCheck,
   Globe2,
   HandHeart,
@@ -281,8 +283,14 @@ export function MyAnnualReview() {
   const [error, setError] = useState<string | null>(null);
   const [missingFields, setMissingFields] = useState<string[]>([]);
   const [initialAcademicYear] = useState(emptyForm.academicYear);
+  const [isFormOpen, setIsFormOpen] = useState(true);
 
   const isSubmitted = annualUpdate?.status === 'submitted';
+
+  const foldForm = () => {
+    setIsFormOpen(false);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
 
   const loadAnnualUpdate = useCallback(async (academicYear: string) => {
     setLoading(true);
@@ -293,12 +301,14 @@ export function MyAnnualReview() {
         setAnnualUpdate(data);
         setForm(toFormState(data, academicYear));
         setMessage(null);
+        setIsFormOpen(data.status !== 'submitted');
         return;
       }
 
       const draft = await getMyDraftAnnualUpdate();
       setAnnualUpdate(draft);
       setForm(toFormState(draft, draft?.academicYear ?? academicYear));
+      setIsFormOpen(true);
       setMessage(
         draft && draft.academicYear !== academicYear
           ? `Resumed your draft for ${draft.academicYear}.`
@@ -337,6 +347,7 @@ export function MyAnnualReview() {
       const saved = await saveAnnualUpdateDraft(toPayload(form));
       setAnnualUpdate(saved);
       setMessage('Draft saved.');
+      foldForm();
     } catch (saveError) {
       console.error('Failed to save annual review draft:', saveError);
       setError('Could not save this draft.');
@@ -366,7 +377,8 @@ export function MyAnnualReview() {
       const submitted = await submitAnnualUpdate(toPayload(form));
       setAnnualUpdate(submitted);
       setMissingFields([]);
-      setMessage('Annual review submitted.');
+      setMessage(null);
+      foldForm();
     } catch (submitError) {
       console.error('Failed to submit annual review:', submitError);
       setError('Could not submit this annual review.');
@@ -413,23 +425,50 @@ export function MyAnnualReview() {
                 {isSubmitted ? 'Submitted' : annualUpdate ? 'Draft in progress' : 'Not started'}
               </span>
               <div className="flex gap-2">
-                <Button
-                  variant="secondary"
-                  onClick={handleSaveDraft}
-                  disabled={saving || isSubmitted}
-                  className="bg-white text-ashinaga-teal-700 hover:bg-white/90"
-                >
-                  <Save className="h-4 w-4 mr-2" />
-                  Save Draft
-                </Button>
-                <Button
-                  onClick={handleSubmit}
-                  disabled={saving || isSubmitted}
-                  className="bg-ashinaga-green-900 text-white hover:bg-ashinaga-green-950"
-                >
-                  <Send className="h-4 w-4 mr-2" />
-                  Submit Final
-                </Button>
+                {isFormOpen && !isSubmitted ? (
+                  <>
+                    <Button
+                      variant="secondary"
+                      onClick={handleSaveDraft}
+                      disabled={saving}
+                      className="bg-white text-ashinaga-teal-700 hover:bg-white/90"
+                    >
+                      <Save className="h-4 w-4 mr-2" />
+                      Save Draft
+                    </Button>
+                    <Button
+                      onClick={handleSubmit}
+                      disabled={saving}
+                      className="bg-ashinaga-green-900 text-white hover:bg-ashinaga-green-950"
+                    >
+                      <Send className="h-4 w-4 mr-2" />
+                      Submit Final
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    variant="secondary"
+                    onClick={() => setIsFormOpen((open) => !open)}
+                    className="bg-white text-ashinaga-teal-700 hover:bg-white/90"
+                  >
+                    {isFormOpen ? (
+                      <>
+                        <ChevronUp className="h-4 w-4 mr-2" />
+                        Hide responses
+                      </>
+                    ) : isSubmitted ? (
+                      <>
+                        <ChevronDown className="h-4 w-4 mr-2" />
+                        View responses
+                      </>
+                    ) : (
+                      <>
+                        <ChevronDown className="h-4 w-4 mr-2" />
+                        Continue editing
+                      </>
+                    )}
+                  </Button>
+                )}
               </div>
             </div>
           </div>
@@ -454,12 +493,12 @@ export function MyAnnualReview() {
         <Alert>
           <CheckCircle className="h-4 w-4" />
           <AlertDescription>
-            This annual review has been submitted and can no longer be edited.
+            Your annual review has been submitted and can no longer be edited.
           </AlertDescription>
         </Alert>
       )}
 
-      {message && (
+      {message && !isSubmitted && (
         <Alert>
           <CheckCircle className="h-4 w-4" />
           <AlertDescription>{message}</AlertDescription>
@@ -485,219 +524,242 @@ export function MyAnnualReview() {
         </Alert>
       )}
 
-      <ReviewSection
-        icon={Sparkles}
-        title="Year Overview"
-        description="Start with the year you are reporting on and the moments you want Ashinaga to know about."
-      >
-        <div className="space-y-6">
-          <div className="grid gap-2">
-            <RequiredLabel htmlFor="academicYear">Academic year</RequiredLabel>
-            <Input
-              id="academicYear"
-              value={form.academicYear}
-              readOnly
-              disabled
-              className="md:max-w-xs bg-muted"
-            />
-          </div>
+      {!isFormOpen && (
+        <Card className="overflow-hidden border bg-white shadow-sm dark:border-sidebar-border dark:bg-sidebar">
+          <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-base font-semibold">{form.academicYear} Annual Review</p>
+              {!isSubmitted && (
+                <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                  Your draft is saved. Continue editing whenever you are ready.
+                </p>
+              )}
+            </div>
+            <Button variant="outline" onClick={() => setIsFormOpen(true)}>
+              <ChevronDown className="h-4 w-4 mr-2" />
+              {isSubmitted ? 'View responses' : 'Continue editing'}
+            </Button>
+          </CardContent>
+        </Card>
+      )}
 
-          <LongTextField
-            id="highlights"
-            label="Please describe any highlights; such as distinctions, awards, accomplishments, projects, or anything you are particularly proud of."
-            required
-            value={form.highlights}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('highlights', value)}
-          />
-        </div>
-      </ReviewSection>
+      {isFormOpen && (
+        <>
+          <ReviewSection
+            icon={Sparkles}
+            title="Year Overview"
+            description="This review is for the academic year shown below. Share important moments you would like Ashinaga to know about."
+          >
+            <div className="space-y-6">
+              <div className="grid gap-2">
+                <RequiredLabel htmlFor="academicYear">Academic year</RequiredLabel>
+                <Input
+                  id="academicYear"
+                  value={form.academicYear}
+                  readOnly
+                  disabled
+                  className="md:max-w-xs bg-muted"
+                />
+              </div>
 
-      <ReviewSection
-        icon={BriefcaseBusiness}
-        title="Work And Activities"
-        description="Share employment, extracurriculars, personal projects, clubs, and other activities from the year."
-      >
-        <div className="space-y-6">
-          <LongTextField
-            id="partTimeJobs"
-            label="Over the last year, have you had any part-time job(s)? Please briefly describe them."
-            required
-            value={form.partTimeJobs}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('partTimeJobs', value)}
-          />
+              <LongTextField
+                id="highlights"
+                label="Please describe any highlights; such as distinctions, awards, accomplishments, projects, or anything you are particularly proud of."
+                required
+                value={form.highlights}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('highlights', value)}
+              />
+            </div>
+          </ReviewSection>
 
-          <LongTextField
-            id="extracurriculars"
-            label="Extracurriculars: What activities did you get involved in, such as hobbies, personal projects, clubs, etc.?"
-            required
-            value={form.extracurriculars}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('extracurriculars', value)}
-          />
-        </div>
-      </ReviewSection>
+          <ReviewSection
+            icon={BriefcaseBusiness}
+            title="Work And Activities"
+            description="Share employment, extracurriculars, personal projects, clubs, and other activities from the year."
+          >
+            <div className="space-y-6">
+              <LongTextField
+                id="partTimeJobs"
+                label="Over the last year, have you had any part-time job(s)? Please briefly describe them."
+                required
+                value={form.partTimeJobs}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('partTimeJobs', value)}
+              />
 
-      <ReviewSection
-        icon={HandHeart}
-        title="Leadership And Pay It Forward"
-        description="Summarise leadership roles and ways you passed kindness forward this year."
-      >
-        <div className="space-y-6">
-          <LongTextField
-            id="leadershipRolesDescription"
-            label="Leadership roles description: Describe the roles, organisations, events, etc."
-            required
-            value={form.leadershipRolesDescription}
-            disabled={saving || isSubmitted}
-            wordLimit={WORD_LIMIT}
-            onChange={(value) => updateField('leadershipRolesDescription', value)}
-          />
+              <LongTextField
+                id="extracurriculars"
+                label="Extracurriculars: What activities did you get involved in, such as hobbies, personal projects, clubs, etc.?"
+                required
+                value={form.extracurriculars}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('extracurriculars', value)}
+              />
+            </div>
+          </ReviewSection>
 
-          <NumberField
-            id="leadershipRolesCount"
-            label="How many leadership roles this year?"
-            required
-            value={form.leadershipRolesCount}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('leadershipRolesCount', value)}
-          />
+          <ReviewSection
+            icon={HandHeart}
+            title="Leadership and Impact"
+            description="Summarise your leadership roles and the ways you have passed kindness forward this year."
+          >
+            <div className="space-y-6">
+              <NumberField
+                id="leadershipRolesCount"
+                label="How many leadership roles have you held this year?"
+                required
+                value={form.leadershipRolesCount}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('leadershipRolesCount', value)}
+              />
 
-          <LongTextField
-            id="payItForwardDescription"
-            label="How have you paid it forward this year? Defined as passing on the kindness you have received, above and beyond everyday kindness, with no expectation of return."
-            required
-            value={form.payItForwardDescription}
-            disabled={saving || isSubmitted}
-            wordLimit={WORD_LIMIT}
-            onChange={(value) => updateField('payItForwardDescription', value)}
-          />
+              <LongTextField
+                id="leadershipRolesDescription"
+                label="Leadership roles description: Describe the roles, organisations, events, etc."
+                required
+                value={form.leadershipRolesDescription}
+                disabled={saving || isSubmitted}
+                wordLimit={WORD_LIMIT}
+                onChange={(value) => updateField('leadershipRolesDescription', value)}
+              />
 
-          <NumberField
-            id="payItForwardCount"
-            label="How many pay-it-forward activities this year?"
-            required
-            value={form.payItForwardCount}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('payItForwardCount', value)}
-          />
-        </div>
-      </ReviewSection>
+              <NumberField
+                id="payItForwardCount"
+                label="How many pay-it-forward activities have you taken part in this year? (Defined as passing on the kindness you have received, above and beyond everyday kindness, with no expectation of return.)"
+                required
+                value={form.payItForwardCount}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('payItForwardCount', value)}
+              />
 
-      <ReviewSection
-        icon={Globe2}
-        title="Africa Engagement And Internships"
-        description="Capture sub-Saharan Africa-related activities and internship experience."
-      >
-        <div className="space-y-6">
-          <LongTextField
-            id="subSaharanAfricaActivitiesDescription"
-            label="What activities connected to sub-Saharan Africa have you been involved in? Describe the role, organisation, event, etc."
-            required
-            value={form.subSaharanAfricaActivitiesDescription}
-            disabled={saving || isSubmitted}
-            wordLimit={WORD_LIMIT}
-            onChange={(value) => updateField('subSaharanAfricaActivitiesDescription', value)}
-          />
+              <LongTextField
+                id="payItForwardDescription"
+                label="How have you paid it forward this year? Describe the activities."
+                required
+                value={form.payItForwardDescription}
+                disabled={saving || isSubmitted}
+                wordLimit={WORD_LIMIT}
+                onChange={(value) => updateField('payItForwardDescription', value)}
+              />
+            </div>
+          </ReviewSection>
 
-          <NumberField
-            id="subSaharanAfricaActivitiesCount"
-            label="How many sub-Saharan Africa-related activities this year?"
-            required
-            value={form.subSaharanAfricaActivitiesCount}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('subSaharanAfricaActivitiesCount', value)}
-          />
+          <ReviewSection
+            icon={Globe2}
+            title="Africa Engagement And Internships"
+            description="Capture sub-Saharan Africa-related activities and internship experience."
+          >
+            <div className="space-y-6">
+              <NumberField
+                id="subSaharanAfricaActivitiesCount"
+                label="How many sub-Saharan Africa-related activities this year?"
+                required
+                value={form.subSaharanAfricaActivitiesCount}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('subSaharanAfricaActivitiesCount', value)}
+              />
 
-          <NumberField
-            id="independentInternshipsCount"
-            label="How many independently secured internships did you complete this year? Total number anywhere in the world."
-            required
-            value={form.independentInternshipsCount}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('independentInternshipsCount', value)}
-          />
+              <LongTextField
+                id="subSaharanAfricaActivitiesDescription"
+                label="What activities connected to sub-Saharan Africa have you been involved in? Describe the role, organisation, event, etc."
+                required
+                value={form.subSaharanAfricaActivitiesDescription}
+                disabled={saving || isSubmitted}
+                wordLimit={WORD_LIMIT}
+                onChange={(value) => updateField('subSaharanAfricaActivitiesDescription', value)}
+              />
 
-          <LongTextField
-            id="internshipsInAfricaSummary"
-            label="Internships in Africa summary: Describe the positions, roles, etc."
-            required
-            value={form.internshipsInAfricaSummary}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('internshipsInAfricaSummary', value)}
-          />
+              <NumberField
+                id="independentInternshipsCount"
+                label="How many independently secured internships did you complete this year? Total number anywhere in the world."
+                required
+                value={form.independentInternshipsCount}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('independentInternshipsCount', value)}
+              />
 
-          <LongTextField
-            id="internshipsElsewhereSummary"
-            label="Internships in UK, or elsewhere except Africa summary: Describe the positions, roles, etc."
-            required
-            value={form.internshipsElsewhereSummary}
-            disabled={saving || isSubmitted}
-            onChange={(value) => updateField('internshipsElsewhereSummary', value)}
-          />
+              <LongTextField
+                id="internshipsInAfricaSummary"
+                label="Internships in Africa summary: Describe the positions, roles, etc."
+                required
+                value={form.internshipsInAfricaSummary}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('internshipsInAfricaSummary', value)}
+              />
 
-          <div className="grid gap-2">
-            <RequiredLabel>
-              Did you complete your Ashinaga 8-week internship in sub-Saharan Africa this year?
-            </RequiredLabel>
-            <Select
-              value={form.completedAshinagaAfricaInternship}
-              onValueChange={(value: FormState['completedAshinagaAfricaInternship']) =>
-                updateField('completedAshinagaAfricaInternship', value)
-              }
-              disabled={saving || isSubmitted}
-            >
-              <SelectTrigger className="md:max-w-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="not_answered">Not answered</SelectItem>
-                <SelectItem value="yes">Yes</SelectItem>
-                <SelectItem value="no">No</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
-      </ReviewSection>
+              <LongTextField
+                id="internshipsElsewhereSummary"
+                label="Internships in UK, or elsewhere except Africa summary: Describe the positions, roles, etc."
+                required
+                value={form.internshipsElsewhereSummary}
+                disabled={saving || isSubmitted}
+                onChange={(value) => updateField('internshipsElsewhereSummary', value)}
+              />
 
-      <ReviewSection
-        icon={BookOpen}
-        title="Academic Results"
-        description="Record your classification and weighted grade for the academic year."
-      >
-        <div className="space-y-6">
-          <div className="grid gap-2">
-            <RequiredLabel htmlFor="academicYearAverageClassification">
-              What was your academic year average? Please input according to classification, e.g.
-              1st, 2:1, 2:2, 3rd.
-            </RequiredLabel>
-            <Input
-              id="academicYearAverageClassification"
-              value={form.academicYearAverageClassification}
-              onChange={(event) =>
-                updateField('academicYearAverageClassification', event.target.value)
-              }
-              disabled={saving || isSubmitted}
-              className="md:max-w-md"
-            />
-          </div>
+              <div className="grid gap-2">
+                <RequiredLabel>
+                  Did you complete your Ashinaga 8-week internship in sub-Saharan Africa this year?
+                </RequiredLabel>
+                <Select
+                  value={form.completedAshinagaAfricaInternship}
+                  onValueChange={(value: FormState['completedAshinagaAfricaInternship']) =>
+                    updateField('completedAshinagaAfricaInternship', value)
+                  }
+                  disabled={saving || isSubmitted}
+                >
+                  <SelectTrigger className="md:max-w-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="not_answered">Not answered</SelectItem>
+                    <SelectItem value="yes">Yes</SelectItem>
+                    <SelectItem value="no">No</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </ReviewSection>
 
-          <div className="grid gap-2">
-            <RequiredLabel htmlFor="academicYearWeightedGrade">
-              What is your year average weighted grade for the academic year? For example, 70% /
-              64%.
-            </RequiredLabel>
-            <Input
-              id="academicYearWeightedGrade"
-              value={form.academicYearWeightedGrade}
-              onChange={(event) => updateField('academicYearWeightedGrade', event.target.value)}
-              disabled={saving || isSubmitted}
-              className="md:max-w-md"
-            />
-          </div>
-        </div>
-      </ReviewSection>
+          <ReviewSection
+            icon={BookOpen}
+            title="Academic Results"
+            description="Record your classification and weighted grade for the academic year."
+          >
+            <div className="space-y-6">
+              <div className="grid gap-2">
+                <RequiredLabel htmlFor="academicYearAverageClassification">
+                  What was your academic year average? Please input according to classification,
+                  e.g. 1st, 2:1, 2:2, 3rd.
+                </RequiredLabel>
+                <Input
+                  id="academicYearAverageClassification"
+                  value={form.academicYearAverageClassification}
+                  onChange={(event) =>
+                    updateField('academicYearAverageClassification', event.target.value)
+                  }
+                  disabled={saving || isSubmitted}
+                  className="md:max-w-md"
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <RequiredLabel htmlFor="academicYearWeightedGrade">
+                  What is your year average weighted grade for the academic year? For example, 70% /
+                  64%.
+                </RequiredLabel>
+                <Input
+                  id="academicYearWeightedGrade"
+                  value={form.academicYearWeightedGrade}
+                  onChange={(event) => updateField('academicYearWeightedGrade', event.target.value)}
+                  disabled={saving || isSubmitted}
+                  className="md:max-w-md"
+                />
+              </div>
+            </div>
+          </ReviewSection>
+        </>
+      )}
     </div>
   );
 }
@@ -809,15 +871,20 @@ function NumberField({
   return (
     <div className="grid gap-2">
       {required ? (
-        <RequiredLabel htmlFor={id}>{label}</RequiredLabel>
+        <RequiredLabel htmlFor={id}>
+          {label} <span className="font-normal text-muted-foreground">(Enter a number)</span>
+        </RequiredLabel>
       ) : (
-        <Label htmlFor={id}>{label}</Label>
+        <Label htmlFor={id}>
+          {label} <span className="font-normal text-muted-foreground">(Enter a number)</span>
+        </Label>
       )}
       <Input
         id={id}
         type="text"
         inputMode="numeric"
         pattern="[0-9]*"
+        placeholder="2"
         value={value}
         onChange={(event) => {
           const nextValue = event.target.value;

--- a/apps/scholar/components/my-annual-review.tsx
+++ b/apps/scholar/components/my-annual-review.tsx
@@ -306,14 +306,14 @@ export function MyAnnualReview() {
         setAnnualUpdate(data);
         setForm(toFormState(data, academicYear));
         setMessage(null);
-        setIsFormOpen(data.status !== 'submitted');
+        setIsFormOpen(false);
         return;
       }
 
       const draft = await getMyDraftAnnualUpdate();
       setAnnualUpdate(draft);
       setForm(toFormState(draft, draft?.academicYear ?? academicYear));
-      setIsFormOpen(true);
+      setIsFormOpen(!draft);
       setMessage(
         draft && draft.academicYear !== academicYear
           ? `Resumed your draft for ${draft.academicYear}.`
@@ -628,6 +628,7 @@ export function MyAnnualReview() {
                 required
                 value={form.payItForwardCount}
                 disabled={saving || isSubmitted}
+                showEnterNumberHint={false}
                 onChange={(value) => updateField('payItForwardCount', value)}
               />
 
@@ -858,6 +859,7 @@ function NumberField({
   value,
   disabled,
   onChange,
+  showEnterNumberHint = true,
 }: {
   id: string;
   label: string;
@@ -865,16 +867,21 @@ function NumberField({
   value: string;
   disabled: boolean;
   onChange: (value: string) => void;
+  showEnterNumberHint?: boolean;
 }) {
+  const hint = showEnterNumberHint ? (
+    <span className="font-normal text-muted-foreground">(Enter a number)</span>
+  ) : null;
+
   return (
     <div className="grid gap-2">
       {required ? (
         <RequiredLabel htmlFor={id}>
-          {label} <span className="font-normal text-muted-foreground">(Enter a number)</span>
+          {label} {hint}
         </RequiredLabel>
       ) : (
         <Label htmlFor={id}>
-          {label} <span className="font-normal text-muted-foreground">(Enter a number)</span>
+          {label} {hint}
         </Label>
       )}
       <Input
@@ -882,7 +889,7 @@ function NumberField({
         type="text"
         inputMode="numeric"
         pattern="[0-9]*"
-        placeholder="2"
+        placeholder="e.g. 2"
         value={value}
         onChange={(event) => {
           const nextValue = event.target.value;

--- a/apps/scholar/components/my-annual-review.tsx
+++ b/apps/scholar/components/my-annual-review.tsx
@@ -292,6 +292,11 @@ export function MyAnnualReview() {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
+  const toggleFormOpen = () => {
+    setIsFormOpen((open) => !open);
+    setMessage(null);
+  };
+
   const loadAnnualUpdate = useCallback(async (academicYear: string) => {
     setLoading(true);
     setError(null);
@@ -325,6 +330,15 @@ export function MyAnnualReview() {
   useEffect(() => {
     loadAnnualUpdate(initialAcademicYear);
   }, [initialAcademicYear, loadAnnualUpdate]);
+
+  useEffect(() => {
+    if (!message) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => setMessage(null), 4000);
+    return () => window.clearTimeout(timeoutId);
+  }, [message]);
 
   const updateField = <K extends keyof FormState>(field: K, value: FormState[K]) => {
     setForm((current) => ({ ...current, [field]: value }));
@@ -424,52 +438,27 @@ export function MyAnnualReview() {
               >
                 {isSubmitted ? 'Submitted' : annualUpdate ? 'Draft in progress' : 'Not started'}
               </span>
-              <div className="flex gap-2">
-                {isFormOpen && !isSubmitted ? (
-                  <>
-                    <Button
-                      variant="secondary"
-                      onClick={handleSaveDraft}
-                      disabled={saving}
-                      className="bg-white text-ashinaga-teal-700 hover:bg-white/90"
-                    >
-                      <Save className="h-4 w-4 mr-2" />
-                      Save Draft
-                    </Button>
-                    <Button
-                      onClick={handleSubmit}
-                      disabled={saving}
-                      className="bg-ashinaga-green-900 text-white hover:bg-ashinaga-green-950"
-                    >
-                      <Send className="h-4 w-4 mr-2" />
-                      Submit Final
-                    </Button>
-                  </>
-                ) : (
+              {isFormOpen && !isSubmitted && (
+                <div className="flex gap-2">
                   <Button
                     variant="secondary"
-                    onClick={() => setIsFormOpen((open) => !open)}
+                    onClick={handleSaveDraft}
+                    disabled={saving}
                     className="bg-white text-ashinaga-teal-700 hover:bg-white/90"
                   >
-                    {isFormOpen ? (
-                      <>
-                        <ChevronUp className="h-4 w-4 mr-2" />
-                        Hide responses
-                      </>
-                    ) : isSubmitted ? (
-                      <>
-                        <ChevronDown className="h-4 w-4 mr-2" />
-                        View responses
-                      </>
-                    ) : (
-                      <>
-                        <ChevronDown className="h-4 w-4 mr-2" />
-                        Continue editing
-                      </>
-                    )}
+                    <Save className="h-4 w-4 mr-2" />
+                    Save Draft
                   </Button>
-                )}
-              </div>
+                  <Button
+                    onClick={handleSubmit}
+                    disabled={saving}
+                    className="bg-ashinaga-green-900 text-white hover:bg-ashinaga-green-950"
+                  >
+                    <Send className="h-4 w-4 mr-2" />
+                    Submit Final
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -524,20 +513,29 @@ export function MyAnnualReview() {
         </Alert>
       )}
 
-      {!isFormOpen && (
+      {annualUpdate && (
         <Card className="overflow-hidden border bg-white shadow-sm dark:border-sidebar-border dark:bg-sidebar">
           <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <p className="text-base font-semibold">{form.academicYear} Annual Review</p>
-              {!isSubmitted && (
+              {!isFormOpen && !isSubmitted && (
                 <p className="mt-1 text-sm leading-6 text-muted-foreground">
                   Your draft is saved. Continue editing whenever you are ready.
                 </p>
               )}
             </div>
-            <Button variant="outline" onClick={() => setIsFormOpen(true)}>
-              <ChevronDown className="h-4 w-4 mr-2" />
-              {isSubmitted ? 'View responses' : 'Continue editing'}
+            <Button variant="outline" onClick={toggleFormOpen}>
+              {isFormOpen ? (
+                <>
+                  <ChevronUp className="h-4 w-4 mr-2" />
+                  {isSubmitted ? 'Hide responses' : 'Hide form'}
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-4 w-4 mr-2" />
+                  {isSubmitted ? 'View responses' : 'Continue editing'}
+                </>
+              )}
             </Button>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Folds the scholar Annual Review form after Save Draft and after Submit Final, with Continue editing / View responses instead of leaving the full form open.
- Collapses submitted confirmation to a single line, and applies the stakeholder copy/order edits (Leadership and Impact, counts before descriptions, number hints). Year Overview no longer asks scholars to choose a year, because that field is locked.

## Screenshots
<img width="748" height="379" alt="image" src="https://github.com/user-attachments/assets/72ca0673-541d-4a7e-badc-c716347109a7" />

## Test plan
- [ ] Scholar: open My Annual Review as a new/in-progress form and check Year Overview subtitle, Leadership and Impact copy, count-before-description order, and “(Enter a number)” / placeholder `2`
- [ ] Scholar: fill some fields → Save Draft → form folds, “Draft saved.” shows, Continue editing restores the draft
- [ ] Scholar: leave and come back → draft is still there
- [ ] Scholar: Submit Final with missing fields → still blocked
- [ ] Scholar: submit a complete review → form folds, one confirmation line only, View responses is read-only
- [ ] Staff: submitted review still appears on Annual Reviews / scholar profile as before