### PR TITLE
fix(scholar): readable request attachments in dark mode (ASH-102)

### DIFF
--- a/apps/scholar/components/new-request-dialog.tsx
+++ b/apps/scholar/components/new-request-dialog.tsx
@@ -1016,24 +1016,28 @@ export function NewRequestDialog({ trigger, onSuccess }: NewRequestDialogProps) 
               />
 
               {selectedFiles.length > 0 && (
-                <div className="space-y-2 p-3 bg-gray-50 rounded-lg">
+                <div className="space-y-2 rounded-lg bg-muted p-3">
                   {selectedFiles.map((file, index) => {
                     const progress = uploadProgress.find((p) => p.file === file);
                     return (
                       <div
                         key={`${file.name}-${file.size}-${file.lastModified}`}
-                        className="flex items-center justify-between p-2 bg-white rounded border"
+                        className="flex items-center justify-between rounded border border-border bg-background p-2"
                       >
-                        <div className="flex items-center gap-2 flex-1">
-                          <FileText className="h-4 w-4 text-gray-500" />
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium truncate">{file.name}</p>
-                            <p className="text-xs text-gray-500">{formatFileSize(file.size)}</p>
+                        <div className="flex flex-1 items-center gap-2">
+                          <FileText className="h-4 w-4 text-muted-foreground" />
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate text-sm font-medium text-foreground">
+                              {file.name}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              {formatFileSize(file.size)}
+                            </p>
                             {progress && progress.status === 'uploading' && (
-                              <Progress value={progress.progress} className="h-1 mt-1" />
+                              <Progress value={progress.progress} className="mt-1 h-1" />
                             )}
                             {progress && progress.status === 'error' && (
-                              <p className="text-xs text-red-600 mt-1">{progress.error}</p>
+                              <p className="mt-1 text-xs text-destructive">{progress.error}</p>
                             )}
                           </div>
                         </div>
@@ -1042,6 +1046,7 @@ export function NewRequestDialog({ trigger, onSuccess }: NewRequestDialogProps) 
                             type="button"
                             variant="ghost"
                             size="sm"
+                            className="text-muted-foreground hover:text-foreground"
                             onClick={() => removeFile(index)}
                           >
                             <X className="h-4 w-4" />
@@ -1053,7 +1058,7 @@ export function NewRequestDialog({ trigger, onSuccess }: NewRequestDialogProps) 
                 </div>
               )}
 
-              <p className="text-xs text-gray-500">
+              <p className="text-xs text-muted-foreground">
                 Accepted formats: PDF, Word, Excel, Text, Images. Max size: 10MB per file.
               </p>
               {fieldError('attachments')}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace hardcoded `bg-gray-50` / `bg-white` / `text-gray-500` on the scholar Submit New Request attachment list with theme tokens (`bg-muted`, `bg-background`, `text-foreground`, `text-muted-foreground`, `border-border`).
- Ensures filename, file size, remove control, and accepted-formats helper text have sufficient contrast in both light and dark mode (ASH-102).

## PR Checklist (Skills)

- [x] N/A — no skill package changes in this PR.

## Validation Notes

- Manual UI verification on scholar portal (`localhost:4002`):
  - Dark mode: attached `IMG_8317.png` — filename, size, remove control, and helper text readable.
  - Light mode: same attachment row remains readable.
- Evidence:
  [Dark mode attachment contrast](https://cursor.com/agents/bc-01a040b8-fc2e-7728-85ed-f8633212c6dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fattachment-dark-mode.webp)
  [Light mode attachment contrast](https://cursor.com/agents/bc-01a040b8-fc2e-7728-85ed-f8633212c6dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fattachment-light-mode.webp)
  [request-attachment-dark-mode-contrast.mp4](https://cursor.com/agents/bc-01a040b8-fc2e-7728-85ed-f8633212c6dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frequest-attachment-dark-mode-contrast.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a040b8-fc2e-7728-85ed-f8633212c6dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a040b8-fc2e-7728-85ed-f8633212c6dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

