### PR TITLE
ASH-80: Track required Prep Year document uploads

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { AnnualUpdatesModule } from './annual-updates/annual-updates.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
+import { DocumentsModule } from './documents/documents.module';
 import { EmailModule } from './email/email.module';
 import { FilesModule } from './files/files.module';
 import { GoalsModule } from './goals/goals.module';
@@ -33,6 +34,7 @@ import { UsersModule } from './users/users.module';
     FilesModule,
     GoalsModule,
     ResourcesModule,
+    DocumentsModule,
     AnnualUpdatesModule,
   ],
   controllers: [AppController],

--- a/apps/api/src/db/migrations/0020_mysterious_dexter_bennett.sql
+++ b/apps/api/src/db/migrations/0020_mysterious_dexter_bennett.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "required_document_files" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"scholar_id" uuid NOT NULL,
+	"type_id" uuid NOT NULL,
+	"file_key" text NOT NULL,
+	"file_name" text NOT NULL,
+	"file_mime_type" text NOT NULL,
+	"file_size_bytes" integer NOT NULL,
+	"uploaded_by" text NOT NULL,
+	"uploaded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "required_document_types" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"slug" text NOT NULL,
+	"label" text NOT NULL,
+	"description" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "required_document_types_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+ALTER TABLE "required_document_files" ADD CONSTRAINT "required_document_files_scholar_id_scholars_id_fk" FOREIGN KEY ("scholar_id") REFERENCES "public"."scholars"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "required_document_files" ADD CONSTRAINT "required_document_files_type_id_required_document_types_id_fk" FOREIGN KEY ("type_id") REFERENCES "public"."required_document_types"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "required_document_files" ADD CONSTRAINT "required_document_files_uploaded_by_user_id_fk" FOREIGN KEY ("uploaded_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "required_document_files_scholar_type_unique" ON "required_document_files" USING btree ("scholar_id","type_id");--> statement-breakpoint
+INSERT INTO "required_document_types" ("id", "slug", "label", "description", "is_active", "sort_order")
+VALUES
+  ('a1000000-0000-4000-8000-000000000001', 'passport', 'Passport copy', 'A clear copy of the candidate''s passport', true, 1),
+  ('a1000000-0000-4000-8000-000000000002', 'transcripts', 'Transcripts', 'Academic transcripts', true, 2),
+  ('a1000000-0000-4000-8000-000000000003', 'ielts', 'IELTS results', 'IELTS (or equivalent) test results', true, 3)
+ON CONFLICT ("slug") DO NOTHING;

--- a/apps/api/src/db/migrations/meta/0020_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0020_snapshot.json
@@ -1,0 +1,2962 @@
+{
+  "id": "51ac0cbf-b2a2-4eb3-a8f5-93f90261537a",
+  "prevId": "a9f3c2e1-4b58-4d70-9c1a-6e8f2d0b5a47",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.announcement_filters": {
+      "name": "announcement_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_value": {
+          "name": "filter_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_filters_announcement_id_announcements_id_fk": {
+          "name": "announcement_filters_announcement_id_announcements_id_fk",
+          "tableFrom": "announcement_filters",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcement_recipients": {
+      "name": "announcement_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scholar_id": {
+          "name": "scholar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcement_recipients_announcement_id_announcements_id_fk": {
+          "name": "announcement_recipients_announcement_id_announcements_id_fk",
+          "tableFrom": "announcement_recipients",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "announcement_recipients_scholar_id_scholars_id_fk": {
+          "name": "announcement_recipients_scholar_id_scholars_id_fk",
+          "tableFrom": "announcement_recipients",
+          "tableTo": "scholars",
+          "columnsFrom": [
+            "scholar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "announcements_created_by_user_id_fk": {
+          "name": "announcements_created_by_user_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "announcements_archived_by_user_id_fk": {
+          "name": "announcements_archived_by_user_id_fk",
+          "tableFrom": "announcements",
+          "tableTo": "user",
+          "columnsFrom": [
+            "archived_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.annual_updates": {
+      "name": "annual_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scholar_id": {
+          "name": "scholar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "academic_year": {
+          "name": "academic_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "annual_update_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "part_time_jobs": {
+          "name": "part_time_jobs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracurriculars": {
+          "name": "extracurriculars",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leadership_roles_description": {
+          "name": "leadership_roles_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leadership_roles_count": {
+          "name": "leadership_roles_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pay_it_forward_description": {
+          "name": "pay_it_forward_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pay_it_forward_count": {
+          "name": "pay_it_forward_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_saharan_africa_activities_description": {
+          "name": "sub_saharan_africa_activities_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_saharan_africa_activities_count": {
+          "name": "sub_saharan_africa_activities_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "independent_internships_count": {
+          "name": "independent_internships_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internships_in_africa_summary": {
+          "name": "internships_in_africa_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "internships_elsewhere_summary": {
+          "name": "internships_elsewhere_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_ashinaga_africa_internship": {
+          "name": "completed_ashinaga_africa_internship",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year_average_classification": {
+          "name": "academic_year_average_classification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "academic_year_weighted_grade": {
+          "name": "academic_year_weighted_grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "annual_updates_scholar_academic_year_unique": {
+          "name": "annual_updates_scholar_academic_year_unique",
+          "columns": [
+            {
+              "expression": "scholar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "academic_year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "annual_updates_scholar_id_scholars_id_fk": {
+          "name": "annual_updates_scholar_id_scholars_id_fk",
+          "tableFrom": "annual_updates",
+          "tableTo": "scholars",
+          "columnsFrom": [
+            "scholar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scholar_id": {
+          "name": "scholar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "upload_date": {
+          "name": "upload_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_scholar_id_scholars_id_fk": {
+          "name": "documents_scholar_id_scholars_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "scholars",
+          "columnsFrom": [
+            "scholar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_uploaded_by_user_id_fk": {
+          "name": "documents_uploaded_by_user_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goal_comments": {
+      "name": "goal_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goal_comments_goal_id_goals_id_fk": {
+          "name": "goal_comments_goal_id_goals_id_fk",
+          "tableFrom": "goal_comments",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_comments_user_id_user_id_fk": {
+          "name": "goal_comments_user_id_user_id_fk",
+          "tableFrom": "goal_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "goal_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "term": {
+          "name": "term",
+          "type": "goal_term",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "related_skills": {
+          "name": "related_skills",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_plan": {
+          "name": "action_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_notes": {
+          "name": "review_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_scale": {
+          "name": "completion_scale",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "goal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scholar_id": {
+          "name": "scholar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_scholar_id_scholars_id_fk": {
+          "name": "goals_scholar_id_scholars_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "scholars",
+          "columnsFrom": [
+            "scholar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'false'"
+        },
+        "completed_date": {
+          "name": "completed_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_goal_id_goals_id_fk": {
+          "name": "milestones_goal_id_goals_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scholar_data": {
+          "name": "scholar_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_resent_at": {
+          "name": "last_resent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resent_count": {
+          "name": "resent_count",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_invited_by_user_id_fk": {
+          "name": "invitations_invited_by_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_user_id_user_id_fk": {
+          "name": "invitations_user_id_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_email_unique": {
+          "name": "invitations_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_assignees": {
+      "name": "request_assignees",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_assignees_request_id_requests_id_fk": {
+          "name": "request_assignees_request_id_requests_id_fk",
+          "tableFrom": "request_assignees",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "request_assignees_user_id_user_id_fk": {
+          "name": "request_assignees_user_id_user_id_fk",
+          "tableFrom": "request_assignees",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "request_assignees_request_id_user_id_pk": {
+          "name": "request_assignees_request_id_user_id_pk",
+          "columns": [
+            "request_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_attachments": {
+      "name": "request_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_attachments_request_id_requests_id_fk": {
+          "name": "request_attachments_request_id_requests_id_fk",
+          "tableFrom": "request_attachments",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.request_audit_logs": {
+      "name": "request_audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "performed_by": {
+          "name": "performed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_status": {
+          "name": "previous_status",
+          "type": "request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "request_audit_logs_request_id_requests_id_fk": {
+          "name": "request_audit_logs_request_id_requests_id_fk",
+          "tableFrom": "request_audit_logs",
+          "tableTo": "requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "request_audit_logs_performed_by_user_id_fk": {
+          "name": "request_audit_logs_performed_by_user_id_fk",
+          "tableFrom": "request_audit_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "performed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.requests": {
+      "name": "requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scholar_id": {
+          "name": "scholar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "form_data": {
+          "name": "form_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "request_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "status": {
+          "name": "status",
+          "type": "request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "submitted_date": {
+          "name": "submitted_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_comment": {
+          "name": "review_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_date": {
+          "name": "review_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_by": {
+          "name": "archived_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "requests_scholar_id_scholars_id_fk": {
+          "name": "requests_scholar_id_scholars_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "scholars",
+          "columnsFrom": [
+            "scholar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requests_assigned_to_user_id_fk": {
+          "name": "requests_assigned_to_user_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requests_reviewed_by_user_id_fk": {
+          "name": "requests_reviewed_by_user_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requests_archived_by_user_id_fk": {
+          "name": "requests_archived_by_user_id_fk",
+          "tableFrom": "requests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "archived_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.required_document_files": {
+      "name": "required_document_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "scholar_id": {
+          "name": "scholar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "required_document_files_scholar_type_unique": {
+          "name": "required_document_files_scholar_type_unique",
+          "columns": [
+            {
+              "expression": "scholar_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "required_document_files_scholar_id_scholars_id_fk": {
+          "name": "required_document_files_scholar_id_scholars_id_fk",
+          "tableFrom": "required_document_files",
+          "tableTo": "scholars",
+          "columnsFrom": [
+            "scholar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "required_document_files_type_id_required_document_types_id_fk": {
+          "name": "required_document_files_type_id_required_document_types_id_fk",
+          "tableFrom": "required_document_files",
+          "tableTo": "required_document_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "required_document_files_uploaded_by_user_id_fk": {
+          "name": "required_document_files_uploaded_by_user_id_fk",
+          "tableFrom": "required_document_files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.required_document_types": {
+      "name": "required_document_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "required_document_types_slug_unique": {
+          "name": "required_document_types_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_filters": {
+      "name": "resource_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_type": {
+          "name": "filter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_value": {
+          "name": "filter_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_filters_resource_id_idx": {
+          "name": "resource_filters_resource_id_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_filters_resource_id_resources_id_fk": {
+          "name": "resource_filters_resource_id_resources_id_fk",
+          "tableFrom": "resource_filters",
+          "tableTo": "resources",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "resource_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "resource_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "resource_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'url'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_mime_type": {
+          "name": "file_mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "resource_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resources_created_by_user_id_fk": {
+          "name": "resources_created_by_user_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "resources_updated_by_user_id_fk": {
+          "name": "resources_updated_by_user_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resources_source_columns_check": {
+          "name": "resources_source_columns_check",
+          "value": "(\n        (\"resources\".\"source_type\" = 'url' AND \"resources\".\"url\" IS NOT NULL AND \"resources\".\"file_key\" IS NULL)\n        OR\n        (\"resources\".\"source_type\" = 'file' AND \"resources\".\"file_key\" IS NOT NULL AND \"resources\".\"url\" IS NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scholars": {
+      "name": "scholars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program": {
+          "name": "program",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university": {
+          "name": "university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "scholar_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aai_scholar_id": {
+          "name": "aai_scholar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "gender",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nationality": {
+          "name": "nationality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_home_country": {
+          "name": "address_home_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passport_expiration_date": {
+          "name": "passport_expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visa_expiration_date": {
+          "name": "visa_expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_country_of_study": {
+          "name": "emergency_contact_country_of_study",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_home_country": {
+          "name": "emergency_contact_home_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graduation_date": {
+          "name": "graduation_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "university_id": {
+          "name": "university_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dietary_information": {
+          "name": "dietary_information",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kokorozashi": {
+          "name": "kokorozashi",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_term_career_plan": {
+          "name": "long_term_career_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "post_graduation_plan": {
+          "name": "post_graduation_plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "major_category": {
+          "name": "major_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "field_of_study": {
+          "name": "field_of_study",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_stage": {
+          "name": "program_stage",
+          "type": "program_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scholar'"
+        },
+        "intended_university": {
+          "name": "intended_university",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intended_course": {
+          "name": "intended_course",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "degree_pathway": {
+          "name": "degree_pathway",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scholars_user_id_user_id_fk": {
+          "name": "scholars_user_id_user_id_fk",
+          "tableFrom": "scholars",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scholars_user_id_unique": {
+          "name": "scholars_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "scholars_aai_scholar_id_unique": {
+          "name": "scholars_aai_scholar_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "aai_scholar_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_attachments": {
+      "name": "task_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_response_id": {
+          "name": "task_response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_attachments_task_response_id_task_responses_id_fk": {
+          "name": "task_attachments_task_response_id_task_responses_id_fk",
+          "tableFrom": "task_attachments",
+          "tableTo": "task_responses",
+          "columnsFrom": [
+            "task_response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_responses": {
+      "name": "task_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_text": {
+          "name": "response_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_responses_task_id_tasks_id_fk": {
+          "name": "task_responses_task_id_tasks_id_fk",
+          "tableFrom": "task_responses",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_responses_task_id_unique": {
+          "name": "task_responses_task_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "task_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "task_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "task_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "scholar_id": {
+          "name": "scholar_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_scholar_id_scholars_id_fk": {
+          "name": "tasks_scholar_id_scholars_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "scholars",
+          "columnsFrom": [
+            "scholar_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_assigned_by_user_id_fk": {
+          "name": "tasks_assigned_by_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_deleted_by_user_id_fk": {
+          "name": "tasks_deleted_by_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "user",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staff": {
+      "name": "staff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_super_admin": {
+          "name": "is_super_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "staff_user_id_user_id_fk": {
+          "name": "staff_user_id_user_id_fk",
+          "tableFrom": "staff",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "staff_user_id_unique": {
+          "name": "staff_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.annual_update_status": {
+      "name": "annual_update_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "submitted"
+      ]
+    },
+    "public.goal_category": {
+      "name": "goal_category",
+      "schema": "public",
+      "values": [
+        "academic_development",
+        "personal_development",
+        "professional_development"
+      ]
+    },
+    "public.goal_status": {
+      "name": "goal_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "completed"
+      ]
+    },
+    "public.goal_term": {
+      "name": "goal_term",
+      "schema": "public",
+      "values": [
+        "term_1",
+        "term_2",
+        "term_3"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "expired",
+        "cancelled"
+      ]
+    },
+    "public.request_priority": {
+      "name": "request_priority",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "public.request_status": {
+      "name": "request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected",
+        "reviewed",
+        "commented"
+      ]
+    },
+    "public.request_type": {
+      "name": "request_type",
+      "schema": "public",
+      "values": [
+        "extenuating_circumstances",
+        "summer_funding_request",
+        "summer_funding_report",
+        "requirement_submission"
+      ]
+    },
+    "public.resource_category": {
+      "name": "resource_category",
+      "schema": "public",
+      "values": [
+        "LDF",
+        "Handbook",
+        "Proposal",
+        "Support"
+      ]
+    },
+    "public.resource_source_type": {
+      "name": "resource_source_type",
+      "schema": "public",
+      "values": [
+        "url",
+        "file"
+      ]
+    },
+    "public.resource_status": {
+      "name": "resource_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "live"
+      ]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": [
+        "Guide",
+        "Handbook",
+        "Template"
+      ]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": [
+        "male",
+        "female",
+        "other",
+        "prefer_not_to_say"
+      ]
+    },
+    "public.program_stage": {
+      "name": "program_stage",
+      "schema": "public",
+      "values": [
+        "prep_year",
+        "scholar"
+      ]
+    },
+    "public.scholar_status": {
+      "name": "scholar_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "on_hold",
+        "archived"
+      ]
+    },
+    "public.task_priority": {
+      "name": "task_priority",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "in_progress",
+        "completed"
+      ]
+    },
+    "public.task_type": {
+      "name": "task_type",
+      "schema": "public",
+      "values": [
+        "document_upload",
+        "form_completion",
+        "meeting_attendance",
+        "goal_update",
+        "feedback_submission",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "admin",
+        "viewer"
+      ]
+    },
+    "public.user_type": {
+      "name": "user_type",
+      "schema": "public",
+      "values": [
+        "staff",
+        "scholar"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1787962200000,
       "tag": "0019_apply_resource_file_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1788055502997,
+      "tag": "0020_mysterious_dexter_bennett",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -5,6 +5,7 @@ export * from './documents';
 export * from './goals';
 export * from './invitations';
 export * from './requests';
+export * from './required-documents';
 export * from './resources';
 export * from './scholars';
 export * from './task-responses';

--- a/apps/api/src/db/schema/required-documents.ts
+++ b/apps/api/src/db/schema/required-documents.ts
@@ -1,0 +1,40 @@
+import { boolean, integer, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { scholars } from './scholars';
+import { users } from './users';
+
+export const requiredDocumentTypes = pgTable('required_document_types', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  slug: text('slug').notNull().unique(),
+  label: text('label').notNull(),
+  description: text('description'),
+  isActive: boolean('is_active').notNull().default(true),
+  sortOrder: integer('sort_order').notNull().default(0),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const requiredDocumentFiles = pgTable(
+  'required_document_files',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    scholarId: uuid('scholar_id')
+      .notNull()
+      .references(() => scholars.id, { onDelete: 'cascade' }),
+    typeId: uuid('type_id')
+      .notNull()
+      .references(() => requiredDocumentTypes.id),
+    fileKey: text('file_key').notNull(),
+    fileName: text('file_name').notNull(),
+    fileMimeType: text('file_mime_type').notNull(),
+    fileSizeBytes: integer('file_size_bytes').notNull(),
+    uploadedBy: text('uploaded_by')
+      .notNull()
+      .references(() => users.id),
+    uploadedAt: timestamp('uploaded_at', { withTimezone: true }).defaultNow().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('required_document_files_scholar_type_unique').on(table.scholarId, table.typeId),
+  ]
+);

--- a/apps/api/src/documents/document-files.ts
+++ b/apps/api/src/documents/document-files.ts
@@ -13,33 +13,6 @@ export const ALLOWED_DOCUMENT_MIME_TYPES = [
   'image/webp',
 ] as const;
 
-const DOCUMENT_MIME_BY_EXTENSION: Record<string, (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number]> = {
-  '.pdf': 'application/pdf',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.png': 'image/png',
-  '.webp': 'image/webp',
-};
-
-export function resolveDocumentMimeType(
-  fileName: string,
-  fileType?: string | null
-): (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number] | null {
-  if (
-    fileType &&
-    ALLOWED_DOCUMENT_MIME_TYPES.includes(fileType as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number])
-  ) {
-    return fileType === 'image/jpg'
-      ? 'image/jpeg'
-      : (fileType as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number]);
-  }
-
-  const extension = fileName.includes('.')
-    ? `.${fileName.split('.').pop()?.toLowerCase() ?? ''}`
-    : '';
-  return DOCUMENT_MIME_BY_EXTENSION[extension] ?? null;
-}
-
 export function sanitizeDocumentFileName(fileName: string): string {
   const sanitized = fileName
     .replace(/[^a-zA-Z0-9.-]/g, '_')

--- a/apps/api/src/documents/document-files.ts
+++ b/apps/api/src/documents/document-files.ts
@@ -1,0 +1,93 @@
+export const DOCUMENT_PENDING_PREFIX = 'documents/pending/';
+export const DOCUMENT_FILE_MAX_SIZE_BYTES = 10 * 1024 * 1024;
+export const DOCUMENT_UPLOAD_URL_EXPIRES_IN_SECONDS = 300;
+export const DOCUMENT_DOWNLOAD_URL_EXPIRES_IN_SECONDS = 900;
+export const DOCUMENT_DOWNLOAD_DISPOSITIONS = ['attachment', 'inline'] as const;
+export type DocumentDownloadDisposition = (typeof DOCUMENT_DOWNLOAD_DISPOSITIONS)[number];
+
+export const ALLOWED_DOCUMENT_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+] as const;
+
+const DOCUMENT_MIME_BY_EXTENSION: Record<string, (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number]> = {
+  '.pdf': 'application/pdf',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+};
+
+export function resolveDocumentMimeType(
+  fileName: string,
+  fileType?: string | null
+): (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number] | null {
+  if (
+    fileType &&
+    ALLOWED_DOCUMENT_MIME_TYPES.includes(fileType as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number])
+  ) {
+    return fileType === 'image/jpg'
+      ? 'image/jpeg'
+      : (fileType as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number]);
+  }
+
+  const extension = fileName.includes('.')
+    ? `.${fileName.split('.').pop()?.toLowerCase() ?? ''}`
+    : '';
+  return DOCUMENT_MIME_BY_EXTENSION[extension] ?? null;
+}
+
+export function sanitizeDocumentFileName(fileName: string): string {
+  const sanitized = fileName
+    .replace(/[^a-zA-Z0-9.-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/\.{2,}/g, '.');
+  return sanitized.length > 0 ? sanitized.slice(0, 180) : 'document';
+}
+
+export function buildContentDispositionHeader(
+  fileName: string,
+  disposition: DocumentDownloadDisposition = 'attachment'
+): string {
+  const asciiFallback = sanitizeDocumentFileName(fileName);
+  const encoded = encodeURIComponent(fileName.replace(/[\r\n]/g, ''));
+  return `${disposition}; filename="${asciiFallback}"; filename*=UTF-8''${encoded}`;
+}
+
+export function buildPendingDocumentFileKey(
+  scholarId: string,
+  uploadId: string,
+  fileName: string
+): string {
+  return `${DOCUMENT_PENDING_PREFIX}${scholarId}/${uploadId}-${sanitizeDocumentFileName(fileName)}`;
+}
+
+export function buildPermanentDocumentFileKey(
+  scholarId: string,
+  typeId: string,
+  fileName: string,
+  timestamp = Date.now()
+): string {
+  return `documents/${scholarId}/${typeId}/${timestamp}-${sanitizeDocumentFileName(fileName)}`;
+}
+
+export function isPendingDocumentFileKey(fileKey: string, scholarId: string): boolean {
+  const prefix = `${DOCUMENT_PENDING_PREFIX}${scholarId}/`;
+  if (!fileKey.startsWith(prefix) || fileKey.includes('..')) {
+    return false;
+  }
+  const rest = fileKey.slice(prefix.length);
+  return rest.length > 0 && !rest.includes('/');
+}
+
+export function slugifyDocumentTypeLabel(label: string): string {
+  const slug = label
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug.length > 0 ? slug.slice(0, 80) : 'type';
+}

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -1,0 +1,125 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+  ValidationPipe,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+import { AuthGuard } from '../auth/auth.guard';
+import { StaffGuard } from '../auth/staff.guard';
+import { DocumentsService } from './documents.service';
+import {
+  ConfirmDocumentUploadDto,
+  CreateDocumentUploadUrlDto,
+  CreateRequiredDocumentTypeDto,
+  DocumentDownloadQueryDto,
+  GetCohortQueryDto,
+  UpdateRequiredDocumentTypeDto,
+} from './dto/documents.dto';
+
+interface AuthenticatedRequest extends Request {
+  user?: {
+    id: string;
+    email?: string;
+    userType?: string;
+  };
+}
+
+@ApiTags('documents')
+@Controller('api/documents')
+export class DocumentsController {
+  constructor(private readonly documentsService: DocumentsService) {}
+
+  @Get('types')
+  @UseGuards(AuthGuard)
+  async listTypes(@Req() req: AuthenticatedRequest) {
+    return this.documentsService.listTypes(req.user?.userType);
+  }
+
+  @Post('types')
+  @UseGuards(StaffGuard)
+  async createType(
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: CreateRequiredDocumentTypeDto
+  ) {
+    return this.documentsService.createType(dto);
+  }
+
+  @Patch('types/:id')
+  @UseGuards(StaffGuard)
+  async updateType(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: UpdateRequiredDocumentTypeDto
+  ) {
+    return this.documentsService.updateType(id, dto);
+  }
+
+  @Post('upload-url')
+  @UseGuards(AuthGuard)
+  async createUploadUrl(
+    @Body(new ValidationPipe({ transform: true, whitelist: true })) dto: CreateDocumentUploadUrlDto,
+    @Req() req: AuthenticatedRequest
+  ) {
+    return this.documentsService.createUploadUrl(req.user?.id || '', dto);
+  }
+
+  @Post()
+  @UseGuards(AuthGuard)
+  async confirmUpload(
+    @Body(new ValidationPipe({ transform: true, whitelist: true })) dto: ConfirmDocumentUploadDto,
+    @Req() req: AuthenticatedRequest
+  ) {
+    return this.documentsService.confirmUpload(req.user?.id || '', dto);
+  }
+
+  @Get('my-checklist')
+  @UseGuards(AuthGuard)
+  async getMyChecklist(@Req() req: AuthenticatedRequest) {
+    return this.documentsService.getMyChecklist(req.user?.id || '');
+  }
+
+  @Get('cohort')
+  @UseGuards(StaffGuard)
+  async getCohort(
+    @Query(new ValidationPipe({ transform: true, whitelist: true })) query: GetCohortQueryDto
+  ) {
+    return this.documentsService.getCohort(query.missingTypeId);
+  }
+
+  @Get('scholar/:scholarId')
+  @UseGuards(StaffGuard)
+  async getScholarChecklist(@Param('scholarId', ParseUUIDPipe) scholarId: string) {
+    return this.documentsService.getScholarChecklist(scholarId);
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard)
+  async deleteMyFile(@Param('id', ParseUUIDPipe) id: string, @Req() req: AuthenticatedRequest) {
+    return this.documentsService.deleteMyFile(req.user?.id || '', id);
+  }
+
+  @Get(':id/download')
+  @UseGuards(AuthGuard)
+  async getDownloadUrl(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: AuthenticatedRequest,
+    @Query(new ValidationPipe({ transform: true, whitelist: true })) query: DocumentDownloadQueryDto
+  ) {
+    return this.documentsService.getDownloadUrl(
+      id,
+      req.user?.id || '',
+      req.user?.userType,
+      query.disposition ?? 'attachment'
+    );
+  }
+}

--- a/apps/api/src/documents/documents.module.ts
+++ b/apps/api/src/documents/documents.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { StorageModule } from '../storage/storage.module';
+import { DocumentsController } from './documents.controller';
+import { DocumentsService } from './documents.service';
+
+@Module({
+  imports: [StorageModule],
+  controllers: [DocumentsController],
+  providers: [DocumentsService],
+  exports: [DocumentsService],
+})
+export class DocumentsModule {}

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -1,0 +1,526 @@
+import { randomUUID } from 'node:crypto';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, asc, eq, inArray } from 'drizzle-orm';
+import { database } from '../db/connection';
+import { requiredDocumentFiles, requiredDocumentTypes, scholars, users } from '../db/schema';
+import { ObjectStorageService } from '../storage/object-storage';
+import {
+  ALLOWED_DOCUMENT_MIME_TYPES,
+  buildContentDispositionHeader,
+  buildPendingDocumentFileKey,
+  buildPermanentDocumentFileKey,
+  DOCUMENT_DOWNLOAD_URL_EXPIRES_IN_SECONDS,
+  DOCUMENT_FILE_MAX_SIZE_BYTES,
+  DOCUMENT_UPLOAD_URL_EXPIRES_IN_SECONDS,
+  type DocumentDownloadDisposition,
+  isPendingDocumentFileKey,
+  slugifyDocumentTypeLabel,
+} from './document-files';
+import {
+  ConfirmDocumentUploadDto,
+  CreateDocumentUploadUrlDto,
+  CreateRequiredDocumentTypeDto,
+  UpdateRequiredDocumentTypeDto,
+} from './dto/documents.dto';
+
+type PrepScholar = {
+  scholarId: string;
+  userId: string;
+  programStage: 'prep_year' | 'scholar';
+};
+
+@Injectable()
+export class DocumentsService {
+  private readonly logger = new Logger(DocumentsService.name);
+
+  constructor(private readonly objectStorage: ObjectStorageService) {}
+
+  async listTypes(userType?: string) {
+    const rows = await database
+      .select()
+      .from(requiredDocumentTypes)
+      .orderBy(asc(requiredDocumentTypes.sortOrder), asc(requiredDocumentTypes.label));
+
+    if (userType === 'staff') {
+      return rows.map((row) => this.formatType(row));
+    }
+
+    return rows.filter((row) => row.isActive).map((row) => this.formatType(row));
+  }
+
+  async createType(dto: CreateRequiredDocumentTypeDto) {
+    const label = dto.label.trim();
+    if (!label) {
+      throw new BadRequestException('Label is required');
+    }
+
+    const slug = await this.uniqueSlug(slugifyDocumentTypeLabel(label));
+    const maxSort = await database
+      .select({ sortOrder: requiredDocumentTypes.sortOrder })
+      .from(requiredDocumentTypes)
+      .orderBy(asc(requiredDocumentTypes.sortOrder));
+    const nextSort = (maxSort.at(-1)?.sortOrder ?? 0) + 1;
+
+    const [created] = await database
+      .insert(requiredDocumentTypes)
+      .values({
+        slug,
+        label,
+        description: dto.description?.trim() || null,
+        sortOrder: nextSort,
+      })
+      .returning();
+
+    return this.formatType(created);
+  }
+
+  async updateType(typeId: string, dto: UpdateRequiredDocumentTypeDto) {
+    const [existing] = await database
+      .select()
+      .from(requiredDocumentTypes)
+      .where(eq(requiredDocumentTypes.id, typeId))
+      .limit(1);
+
+    if (!existing) {
+      throw new NotFoundException('Document type not found');
+    }
+
+    const nextLabel = dto.label?.trim();
+    let nextSlug = existing.slug;
+    if (nextLabel && nextLabel !== existing.label) {
+      nextSlug = await this.uniqueSlug(slugifyDocumentTypeLabel(nextLabel), typeId);
+    }
+
+    const [updated] = await database
+      .update(requiredDocumentTypes)
+      .set({
+        ...(nextLabel ? { label: nextLabel, slug: nextSlug } : {}),
+        ...(dto.description !== undefined ? { description: dto.description.trim() || null } : {}),
+        ...(dto.isActive !== undefined ? { isActive: dto.isActive } : {}),
+        ...(dto.sortOrder !== undefined ? { sortOrder: dto.sortOrder } : {}),
+        updatedAt: new Date(),
+      })
+      .where(eq(requiredDocumentTypes.id, typeId))
+      .returning();
+
+    return this.formatType(updated);
+  }
+
+  async createUploadUrl(userId: string, dto: CreateDocumentUploadUrlDto) {
+    const scholar = await this.requirePrepScholar(userId);
+    await this.requireActiveType(dto.typeId);
+    this.assertAllowedUpload(dto.fileType, dto.fileSize);
+
+    const fileKey = buildPendingDocumentFileKey(scholar.scholarId, randomUUID(), dto.fileName);
+    const upload = await this.objectStorage.createUploadUrl({
+      key: fileKey,
+      contentType: dto.fileType === 'image/jpg' ? 'image/jpeg' : dto.fileType,
+      contentLength: dto.fileSize,
+      expiresInSeconds: DOCUMENT_UPLOAD_URL_EXPIRES_IN_SECONDS,
+    });
+
+    return { uploadUrl: upload.url, fields: upload.fields, fileKey };
+  }
+
+  async confirmUpload(userId: string, dto: ConfirmDocumentUploadDto) {
+    const scholar = await this.requirePrepScholar(userId);
+    const documentType = await this.requireActiveType(dto.typeId);
+
+    if (!isPendingDocumentFileKey(dto.pendingFileKey, scholar.scholarId)) {
+      throw new BadRequestException('Invalid pending file key');
+    }
+
+    this.assertAllowedUpload(dto.fileMimeType, dto.fileSizeBytes);
+
+    const { fileKey } = await this.copyPendingUpload({
+      pendingFileKey: dto.pendingFileKey,
+      scholarId: scholar.scholarId,
+      typeId: documentType.id,
+      fileName: dto.fileName,
+      fileMimeType: dto.fileMimeType === 'image/jpg' ? 'image/jpeg' : dto.fileMimeType,
+      fileSizeBytes: dto.fileSizeBytes,
+    });
+
+    const [existing] = await database
+      .select()
+      .from(requiredDocumentFiles)
+      .where(
+        and(
+          eq(requiredDocumentFiles.scholarId, scholar.scholarId),
+          eq(requiredDocumentFiles.typeId, documentType.id)
+        )
+      )
+      .limit(1);
+
+    try {
+      if (existing) {
+        const [updated] = await database
+          .update(requiredDocumentFiles)
+          .set({
+            fileKey,
+            fileName: dto.fileName,
+            fileMimeType: dto.fileMimeType === 'image/jpg' ? 'image/jpeg' : dto.fileMimeType,
+            fileSizeBytes: dto.fileSizeBytes,
+            uploadedBy: userId,
+            uploadedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(eq(requiredDocumentFiles.id, existing.id))
+          .returning();
+
+        await this.deleteStoredObject(dto.pendingFileKey, 'pending document upload');
+        if (existing.fileKey !== fileKey) {
+          await this.deleteStoredObject(existing.fileKey, 'replaced document file');
+        }
+        return this.formatFile(updated, documentType);
+      }
+
+      const [created] = await database
+        .insert(requiredDocumentFiles)
+        .values({
+          scholarId: scholar.scholarId,
+          typeId: documentType.id,
+          fileKey,
+          fileName: dto.fileName,
+          fileMimeType: dto.fileMimeType === 'image/jpg' ? 'image/jpeg' : dto.fileMimeType,
+          fileSizeBytes: dto.fileSizeBytes,
+          uploadedBy: userId,
+        })
+        .returning();
+
+      await this.deleteStoredObject(dto.pendingFileKey, 'pending document upload');
+      return this.formatFile(created, documentType);
+    } catch (error) {
+      await this.deleteStoredObject(fileKey, 'copied document file after save failure');
+      if (error instanceof Error && error.message.includes('unique')) {
+        throw new ConflictException('A file already exists for this document type');
+      }
+      throw error;
+    }
+  }
+
+  async deleteMyFile(userId: string, fileId: string) {
+    const scholar = await this.requirePrepScholar(userId);
+    const [file] = await database
+      .select()
+      .from(requiredDocumentFiles)
+      .where(eq(requiredDocumentFiles.id, fileId))
+      .limit(1);
+
+    if (!file || file.scholarId !== scholar.scholarId) {
+      throw new NotFoundException('Document not found');
+    }
+
+    await database.delete(requiredDocumentFiles).where(eq(requiredDocumentFiles.id, fileId));
+    await this.deleteStoredObject(file.fileKey, 'deleted document file');
+    return { success: true };
+  }
+
+  async getMyChecklist(userId: string) {
+    const scholar = await this.requirePrepScholar(userId);
+    return this.getScholarChecklist(scholar.scholarId);
+  }
+
+  async getScholarChecklist(scholarId: string) {
+    const [scholar] = await database
+      .select({ id: scholars.id })
+      .from(scholars)
+      .where(eq(scholars.id, scholarId))
+      .limit(1);
+
+    if (!scholar) {
+      throw new NotFoundException('Scholar not found');
+    }
+
+    const types = await database
+      .select()
+      .from(requiredDocumentTypes)
+      .where(eq(requiredDocumentTypes.isActive, true))
+      .orderBy(asc(requiredDocumentTypes.sortOrder), asc(requiredDocumentTypes.label));
+
+    const files = await database
+      .select()
+      .from(requiredDocumentFiles)
+      .where(eq(requiredDocumentFiles.scholarId, scholarId));
+
+    const fileByType = new Map(files.map((file) => [file.typeId, file]));
+
+    return {
+      scholarId,
+      items: types.map((type) => {
+        const file = fileByType.get(type.id);
+        return {
+          type: this.formatType(type),
+          status: file ? ('submitted' as const) : ('missing' as const),
+          file: file ? this.formatFile(file, type) : null,
+        };
+      }),
+    };
+  }
+
+  async getCohort(missingTypeId?: string) {
+    const types = await database
+      .select()
+      .from(requiredDocumentTypes)
+      .where(eq(requiredDocumentTypes.isActive, true))
+      .orderBy(asc(requiredDocumentTypes.sortOrder), asc(requiredDocumentTypes.label));
+
+    if (missingTypeId && !types.some((type) => type.id === missingTypeId)) {
+      throw new BadRequestException('Unknown or inactive document type');
+    }
+
+    const prepScholars = await database
+      .select({
+        scholarId: scholars.id,
+        name: users.name,
+        email: users.email,
+      })
+      .from(scholars)
+      .innerJoin(users, eq(scholars.userId, users.id))
+      .where(eq(scholars.programStage, 'prep_year'))
+      .orderBy(asc(users.name));
+
+    const scholarIds = prepScholars.map((row) => row.scholarId);
+    const files =
+      scholarIds.length === 0
+        ? []
+        : await database
+            .select()
+            .from(requiredDocumentFiles)
+            .where(inArray(requiredDocumentFiles.scholarId, scholarIds));
+
+    const filesByScholar = new Map<string, Map<string, (typeof files)[number]>>();
+    for (const file of files) {
+      const byType = filesByScholar.get(file.scholarId) ?? new Map();
+      byType.set(file.typeId, file);
+      filesByScholar.set(file.scholarId, byType);
+    }
+
+    const scholarsPayload = prepScholars
+      .map((row) => {
+        const byType = filesByScholar.get(row.scholarId) ?? new Map();
+        const items = types.map((type) => {
+          const file = byType.get(type.id);
+          return {
+            typeId: type.id,
+            status: file ? ('submitted' as const) : ('missing' as const),
+            file: file
+              ? {
+                  id: file.id,
+                  fileName: file.fileName,
+                  uploadedAt: file.uploadedAt,
+                }
+              : null,
+          };
+        });
+        return {
+          scholarId: row.scholarId,
+          name: row.name,
+          email: row.email,
+          items,
+        };
+      })
+      .filter((row) => {
+        if (!missingTypeId) return true;
+        return row.items.some((item) => item.typeId === missingTypeId && item.status === 'missing');
+      });
+
+    return {
+      types: types.map((type) => this.formatType(type)),
+      scholars: scholarsPayload,
+    };
+  }
+
+  async getDownloadUrl(
+    fileId: string,
+    userId: string,
+    userType: string | undefined,
+    disposition: DocumentDownloadDisposition
+  ) {
+    const [file] = await database
+      .select()
+      .from(requiredDocumentFiles)
+      .where(eq(requiredDocumentFiles.id, fileId))
+      .limit(1);
+
+    if (!file) {
+      throw new NotFoundException('Document not found');
+    }
+
+    if (userType !== 'staff') {
+      const [scholar] = await database
+        .select({ id: scholars.id })
+        .from(scholars)
+        .where(eq(scholars.userId, userId))
+        .limit(1);
+
+      if (!scholar || scholar.id !== file.scholarId) {
+        throw new NotFoundException('Document not found');
+      }
+    }
+
+    const downloadUrl = await this.objectStorage.createDownloadUrl({
+      key: file.fileKey,
+      contentDisposition: buildContentDispositionHeader(file.fileName, disposition),
+      expiresInSeconds: DOCUMENT_DOWNLOAD_URL_EXPIRES_IN_SECONDS,
+    });
+
+    return { downloadUrl };
+  }
+
+  async deleteStoredFilesForScholar(scholarId: string): Promise<void> {
+    const files = await database
+      .select({ id: requiredDocumentFiles.id, fileKey: requiredDocumentFiles.fileKey })
+      .from(requiredDocumentFiles)
+      .where(eq(requiredDocumentFiles.scholarId, scholarId));
+
+    for (const file of files) {
+      await this.deleteStoredObject(file.fileKey, 'scholar document file');
+    }
+
+    if (files.length > 0) {
+      await database
+        .delete(requiredDocumentFiles)
+        .where(eq(requiredDocumentFiles.scholarId, scholarId));
+    }
+  }
+
+  private async requirePrepScholar(userId: string): Promise<PrepScholar> {
+    const [row] = await database
+      .select({
+        scholarId: scholars.id,
+        userId: scholars.userId,
+        programStage: scholars.programStage,
+      })
+      .from(scholars)
+      .where(eq(scholars.userId, userId))
+      .limit(1);
+
+    if (!row) {
+      throw new ForbiddenException('Prep Year document uploads are limited to candidates');
+    }
+
+    if (row.programStage !== 'prep_year') {
+      throw new ForbiddenException('Prep Year document uploads are limited to candidates');
+    }
+
+    return row;
+  }
+
+  private async requireActiveType(typeId: string) {
+    const [row] = await database
+      .select()
+      .from(requiredDocumentTypes)
+      .where(eq(requiredDocumentTypes.id, typeId))
+      .limit(1);
+
+    if (!row) {
+      throw new NotFoundException('Document type not found');
+    }
+    if (!row.isActive) {
+      throw new BadRequestException('This document type is no longer required');
+    }
+    return row;
+  }
+
+  private async uniqueSlug(base: string, excludeId?: string): Promise<string> {
+    let candidate = base;
+    let suffix = 2;
+    while (true) {
+      const [existing] = await database
+        .select({ id: requiredDocumentTypes.id })
+        .from(requiredDocumentTypes)
+        .where(eq(requiredDocumentTypes.slug, candidate))
+        .limit(1);
+      if (!existing || existing.id === excludeId) {
+        return candidate;
+      }
+      candidate = `${base}-${suffix}`;
+      suffix += 1;
+    }
+  }
+
+  private async copyPendingUpload(input: {
+    pendingFileKey: string;
+    scholarId: string;
+    typeId: string;
+    fileName: string;
+    fileMimeType: string;
+    fileSizeBytes: number;
+  }) {
+    const uploaded = await this.objectStorage.headObject(input.pendingFileKey);
+    if (!uploaded) {
+      throw new BadRequestException('Uploaded file was not found. Please upload the file again.');
+    }
+
+    if (uploaded.contentLength != null && uploaded.contentLength !== input.fileSizeBytes) {
+      throw new BadRequestException('Uploaded file size does not match the selected file');
+    }
+
+    if (uploaded.contentType && uploaded.contentType !== input.fileMimeType) {
+      throw new BadRequestException('Uploaded file type does not match the selected file');
+    }
+
+    const fileKey = buildPermanentDocumentFileKey(input.scholarId, input.typeId, input.fileName);
+    await this.objectStorage.copyObject(input.pendingFileKey, fileKey);
+    return { fileKey };
+  }
+
+  private assertAllowedUpload(fileType: string, fileSize: number) {
+    const normalized = fileType === 'image/jpg' ? 'image/jpeg' : fileType;
+    if (
+      !ALLOWED_DOCUMENT_MIME_TYPES.includes(
+        normalized as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number]
+      ) &&
+      fileType !== 'image/jpg'
+    ) {
+      throw new BadRequestException(`File type ${fileType} is not allowed`);
+    }
+
+    if (fileSize < 1 || fileSize > DOCUMENT_FILE_MAX_SIZE_BYTES) {
+      throw new BadRequestException('File size exceeds 10MB limit');
+    }
+  }
+
+  private async deleteStoredObject(fileKey: string, label: string): Promise<void> {
+    try {
+      await this.objectStorage.deleteObject(fileKey);
+    } catch (error) {
+      this.logger.warn(`Failed to delete ${label} (${fileKey})`, error);
+    }
+  }
+
+  private formatType(row: typeof requiredDocumentTypes.$inferSelect) {
+    return {
+      id: row.id,
+      slug: row.slug,
+      label: row.label,
+      description: row.description,
+      isActive: row.isActive,
+      sortOrder: row.sortOrder,
+    };
+  }
+
+  private formatFile(
+    row: typeof requiredDocumentFiles.$inferSelect,
+    type?: typeof requiredDocumentTypes.$inferSelect
+  ) {
+    return {
+      id: row.id,
+      typeId: row.typeId,
+      typeSlug: type?.slug,
+      typeLabel: type?.label,
+      fileName: row.fileName,
+      fileMimeType: row.fileMimeType,
+      fileSizeBytes: row.fileSizeBytes,
+      uploadedAt: row.uploadedAt,
+    };
+  }
+}

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -198,6 +198,8 @@ export class DocumentsService {
       await this.deleteStoredObject(dto.pendingFileKey, 'pending document upload');
       return this.formatFile(created, documentType);
     } catch (error) {
+      // Deletes this request's newly copied key, not the winning row's, except a
+      // same-millisecond key collision on the concurrent double-submit path.
       await this.deleteStoredObject(fileKey, 'copied document file after save failure');
       if (error instanceof Error && error.message.includes('unique')) {
         throw new ConflictException('A file already exists for this document type');
@@ -478,13 +480,16 @@ export class DocumentsService {
     if (
       !ALLOWED_DOCUMENT_MIME_TYPES.includes(
         normalized as (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number]
-      ) &&
-      fileType !== 'image/jpg'
+      )
     ) {
       throw new BadRequestException(`File type ${fileType} is not allowed`);
     }
 
-    if (fileSize < 1 || fileSize > DOCUMENT_FILE_MAX_SIZE_BYTES) {
+    if (fileSize < 1) {
+      throw new BadRequestException('File must not be empty');
+    }
+
+    if (fileSize > DOCUMENT_FILE_MAX_SIZE_BYTES) {
       throw new BadRequestException('File size exceeds 10MB limit');
     }
   }

--- a/apps/api/src/documents/documents.upload.spec.ts
+++ b/apps/api/src/documents/documents.upload.spec.ts
@@ -1,0 +1,194 @@
+import { ForbiddenException } from '@nestjs/common';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { database } from '../db/connection';
+import { ObjectStorageService } from '../storage/object-storage';
+import { DocumentsService } from './documents.service';
+
+jest.mock('../db/connection', () => ({
+  database: {
+    select: jest.fn(),
+    insert: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const scholarId = '11111111-1111-4111-8111-111111111111';
+const typeId = 'a1000000-0000-4000-8000-000000000001';
+
+function mockSelectSequence(results: unknown[][]) {
+  let call = 0;
+  (database.select as jest.Mock).mockImplementation(() => {
+    const rows = results[call] ?? [];
+    call += 1;
+    const chain: Record<string, unknown> = {};
+    const thenable = {
+      from: jest.fn().mockReturnValue(chain),
+      innerJoin: jest.fn().mockReturnValue(chain),
+      where: jest.fn().mockReturnValue(chain),
+      orderBy: jest.fn().mockResolvedValue(rows),
+      limit: jest.fn().mockResolvedValue(rows),
+    };
+    Object.assign(chain, thenable);
+    return thenable;
+  });
+}
+
+describe('DocumentsService uploads', () => {
+  let service: DocumentsService;
+  const objectStorage = {
+    createUploadUrl: jest.fn(),
+    createDownloadUrl: jest.fn(),
+    headObject: jest.fn(),
+    copyObject: jest.fn(),
+    deleteObject: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentsService,
+        {
+          provide: ObjectStorageService,
+          useValue: objectStorage,
+        },
+      ],
+    }).compile();
+    service = module.get(DocumentsService);
+  });
+
+  it('creates a scholar-scoped pending upload POST', async () => {
+    mockSelectSequence([
+      [{ scholarId, userId: 'user-1', programStage: 'prep_year' }],
+      [{ id: typeId, slug: 'passport', label: 'Passport copy', isActive: true, sortOrder: 1 }],
+    ]);
+    objectStorage.createUploadUrl.mockResolvedValue({
+      url: 'https://s3.example/post',
+      fields: { Policy: 'policy' },
+    });
+
+    const result = await service.createUploadUrl('user-1', {
+      typeId,
+      fileName: 'passport.pdf',
+      fileType: 'application/pdf',
+      fileSize: 2048,
+    });
+
+    expect(objectStorage.createUploadUrl).toHaveBeenCalledWith({
+      key: expect.stringMatching(new RegExp(`^documents/pending/${scholarId}/.+-passport\\.pdf$`)),
+      contentType: 'application/pdf',
+      contentLength: 2048,
+      expiresInSeconds: 300,
+    });
+    expect(result.fileKey).toMatch(new RegExp(`^documents/pending/${scholarId}/`));
+  });
+
+  it('rejects uploads from confirmed scholars', async () => {
+    mockSelectSequence([[{ scholarId, userId: 'user-1', programStage: 'scholar' }]]);
+
+    await expect(
+      service.createUploadUrl('user-1', {
+        typeId,
+        fileName: 'passport.pdf',
+        fileType: 'application/pdf',
+        fileSize: 2048,
+      })
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('rejects a pending key that belongs to another scholar', async () => {
+    mockSelectSequence([
+      [{ scholarId, userId: 'user-1', programStage: 'prep_year' }],
+      [{ id: typeId, slug: 'passport', label: 'Passport copy', isActive: true, sortOrder: 1 }],
+    ]);
+
+    await expect(
+      service.confirmUpload('user-1', {
+        typeId,
+        pendingFileKey: 'documents/pending/other-scholar/upload-passport.pdf',
+        fileName: 'passport.pdf',
+        fileMimeType: 'application/pdf',
+        fileSizeBytes: 2048,
+      })
+    ).rejects.toThrow('Invalid pending file key');
+    expect(objectStorage.copyObject).not.toHaveBeenCalled();
+  });
+
+  it('copies the pending object then replaces an existing file', async () => {
+    const existing = {
+      id: 'file-1',
+      scholarId,
+      typeId,
+      fileKey: 'documents/old-key.pdf',
+      fileName: 'old.pdf',
+      fileMimeType: 'application/pdf',
+      fileSizeBytes: 100,
+      uploadedBy: 'user-1',
+      uploadedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const updated = { ...existing, fileName: 'passport.pdf', fileKey: 'documents/new-key.pdf' };
+
+    mockSelectSequence([
+      [{ scholarId, userId: 'user-1', programStage: 'prep_year' }],
+      [
+        {
+          id: typeId,
+          slug: 'passport',
+          label: 'Passport copy',
+          description: null,
+          isActive: true,
+          sortOrder: 1,
+        },
+      ],
+      [existing],
+    ]);
+    objectStorage.headObject.mockResolvedValue({
+      contentType: 'application/pdf',
+      contentLength: 2048,
+    });
+    objectStorage.copyObject.mockResolvedValue(undefined);
+    objectStorage.deleteObject.mockResolvedValue(undefined);
+    (database.update as jest.Mock).mockReturnValue({
+      set: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          returning: jest.fn().mockResolvedValue([updated]),
+        }),
+      }),
+    });
+
+    const result = await service.confirmUpload('user-1', {
+      typeId,
+      pendingFileKey: `documents/pending/${scholarId}/upload-passport.pdf`,
+      fileName: 'passport.pdf',
+      fileMimeType: 'application/pdf',
+      fileSizeBytes: 2048,
+    });
+
+    expect(objectStorage.copyObject).toHaveBeenCalledWith(
+      `documents/pending/${scholarId}/upload-passport.pdf`,
+      expect.stringMatching(new RegExp(`^documents/${scholarId}/${typeId}/`))
+    );
+    expect(result.fileName).toBe('passport.pdf');
+  });
+
+  it('hides another scholar file from download', async () => {
+    mockSelectSequence([
+      [
+        {
+          id: 'file-1',
+          scholarId,
+          fileKey: 'documents/key.pdf',
+          fileName: 'passport.pdf',
+        },
+      ],
+      [{ id: 'other-scholar' }],
+    ]);
+
+    await expect(
+      service.getDownloadUrl('file-1', 'outsider', 'scholar', 'attachment')
+    ).rejects.toThrow('Document not found');
+  });
+});

--- a/apps/api/src/documents/dto/documents.dto.ts
+++ b/apps/api/src/documents/dto/documents.dto.ts
@@ -1,0 +1,101 @@
+import { Transform, Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+import {
+  ALLOWED_DOCUMENT_MIME_TYPES,
+  DOCUMENT_DOWNLOAD_DISPOSITIONS,
+  DOCUMENT_FILE_MAX_SIZE_BYTES,
+} from '../document-files';
+
+export class CreateDocumentUploadUrlDto {
+  @IsUUID()
+  typeId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  fileName: string;
+
+  @IsIn(ALLOWED_DOCUMENT_MIME_TYPES)
+  fileType: (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number];
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(DOCUMENT_FILE_MAX_SIZE_BYTES)
+  fileSize: number;
+}
+
+export class ConfirmDocumentUploadDto {
+  @IsUUID()
+  typeId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  pendingFileKey: string;
+
+  @IsString()
+  @IsNotEmpty()
+  fileName: string;
+
+  @IsIn(ALLOWED_DOCUMENT_MIME_TYPES)
+  fileMimeType: (typeof ALLOWED_DOCUMENT_MIME_TYPES)[number];
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(DOCUMENT_FILE_MAX_SIZE_BYTES)
+  fileSizeBytes: number;
+}
+
+export class CreateRequiredDocumentTypeDto {
+  @IsString()
+  @IsNotEmpty()
+  label: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+export class UpdateRequiredDocumentTypeDto {
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  label?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => value === true || value === 'true')
+  @IsBoolean()
+  isActive?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  sortOrder?: number;
+}
+
+export class DocumentDownloadQueryDto {
+  @IsOptional()
+  @IsIn(DOCUMENT_DOWNLOAD_DISPOSITIONS)
+  disposition?: (typeof DOCUMENT_DOWNLOAD_DISPOSITIONS)[number];
+}
+
+export class GetCohortQueryDto {
+  @IsOptional()
+  @IsUUID()
+  missingTypeId?: string;
+}

--- a/apps/api/src/documents/dto/documents.dto.ts
+++ b/apps/api/src/documents/dto/documents.dto.ts
@@ -77,7 +77,18 @@ export class UpdateRequiredDocumentTypeDto {
   description?: string;
 
   @IsOptional()
-  @Transform(({ value }) => value === true || value === 'true')
+  @Transform(({ value }) => {
+    if (value === undefined) {
+      return undefined;
+    }
+    if (value === true || value === 'true') {
+      return true;
+    }
+    if (value === false || value === 'false') {
+      return false;
+    }
+    return value;
+  })
   @IsBoolean()
   isActive?: boolean;
 

--- a/apps/api/src/scholars/scholars.module.ts
+++ b/apps/api/src/scholars/scholars.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
+import { DocumentsModule } from '../documents/documents.module';
 import { InvitationsModule } from '../invitations/invitations.module';
 import { ScholarsController } from './scholars.controller';
 import { ScholarsService } from './scholars.service';
 
 @Module({
-  imports: [InvitationsModule],
+  imports: [InvitationsModule, DocumentsModule],
   controllers: [ScholarsController],
   providers: [ScholarsService],
 })

--- a/apps/api/src/scholars/scholars.service.spec.ts
+++ b/apps/api/src/scholars/scholars.service.spec.ts
@@ -30,6 +30,7 @@ jest.mock('../auth/auth.config', () => ({
   },
 }));
 
+import { DocumentsService } from '../documents/documents.service';
 import { InvitationsService } from '../invitations/invitations.service';
 import type { CreateScholarDto } from './dto/create-scholar.dto';
 import { Gender, ProgramStage } from './dto/update-scholar-profile.dto';
@@ -44,6 +45,9 @@ describe('ScholarsService', () => {
     mockInvitationsService = {
       createInvitation: jest.fn(),
     };
+    const mockDocumentsService = {
+      deleteStoredFilesForScholar: jest.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -51,6 +55,10 @@ describe('ScholarsService', () => {
         {
           provide: InvitationsService,
           useValue: mockInvitationsService,
+        },
+        {
+          provide: DocumentsService,
+          useValue: mockDocumentsService,
         },
       ],
     }).compile();

--- a/apps/api/src/scholars/scholars.service.ts
+++ b/apps/api/src/scholars/scholars.service.ts
@@ -20,6 +20,7 @@ import {
   tasks,
   users,
 } from '../db/schema';
+import { DocumentsService } from '../documents/documents.service';
 import { InvitationsService } from '../invitations/invitations.service';
 import { escapeCsvValue } from '../utils/csv';
 import { isPlaceholderAcademicValue } from './academic-values';
@@ -52,7 +53,10 @@ function uniqueFilterValues(values: Array<string | null | undefined>): string[] 
 
 @Injectable()
 export class ScholarsService {
-  constructor(private readonly invitationsService: InvitationsService) {}
+  constructor(
+    private readonly invitationsService: InvitationsService,
+    private readonly documentsService: DocumentsService
+  ) {}
 
   async createScholar(
     createScholarDto: CreateScholarDto,
@@ -1161,6 +1165,7 @@ export class ScholarsService {
     if (!row) {
       throw new NotFoundException('Scholar not found');
     }
+    await this.documentsService.deleteStoredFilesForScholar(scholarId);
     const goalRows = await database
       .select({ id: goals.id })
       .from(goals)

--- a/apps/api/test/integration/helpers/seed.ts
+++ b/apps/api/test/integration/helpers/seed.ts
@@ -92,7 +92,13 @@ export async function seedStaffUser(
 
 export async function seedScholarUser(
   db: NodePgDatabase,
-  opts: { name?: string; program?: string; year?: string; university?: string } = {}
+  opts: {
+    name?: string;
+    program?: string;
+    year?: string;
+    university?: string;
+    programStage?: 'prep_year' | 'scholar';
+  } = {}
 ): Promise<SeededScholar> {
   const id = nextTag('itest-scholar-user');
   const email = `${id}@example.com`;
@@ -119,6 +125,7 @@ export async function seedScholarUser(
       university: opts.university ?? 'Test University',
       startDate: new Date('2024-09-01'),
       status: 'active',
+      programStage: opts.programStage ?? 'scholar',
     })
     .returning({ id: scholars.id });
 

--- a/apps/api/test/integration/required-documents.integration.spec.ts
+++ b/apps/api/test/integration/required-documents.integration.spec.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { eq } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { Pool } from 'pg';
+import request from 'supertest';
+import { requiredDocumentFiles, requiredDocumentTypes } from '../../src/db/schema';
+import { type AuthContext, createAuthenticatedIntegrationApp } from './helpers/create-app';
+import {
+  cleanupSeeded,
+  getTestPool,
+  type SeededScholar,
+  type SeededStaff,
+  seedScholarUser,
+  seedStaffUser,
+} from './helpers/seed';
+
+describe('Required documents API (integration)', () => {
+  let app: import('@nestjs/platform-fastify').NestFastifyApplication;
+  let auth: AuthContext;
+  let pool: Pool;
+  let db: NodePgDatabase;
+  let staffActor: SeededStaff;
+  let prepScholar: SeededScholar;
+  let enrolledScholar: SeededScholar;
+  let createdFileId: string | undefined;
+  let passportTypeId: string;
+
+  const objectStorage = {
+    createUploadUrl: jest.fn(async (input: { key: string }) => ({
+      url: 'https://s3.example/post',
+      fields: { key: input.key, Policy: 'policy' },
+    })),
+    createDownloadUrl: jest.fn(async () => 'https://s3.example/signed-get'),
+    headObject: jest.fn(async () => ({
+      contentType: 'application/pdf',
+      contentLength: 2048,
+    })),
+    copyObject: jest.fn(async () => undefined),
+    deleteObject: jest.fn(async () => undefined),
+  };
+
+  beforeAll(async () => {
+    const built = await createAuthenticatedIntegrationApp({ objectStorage });
+    app = built.app;
+    auth = built.auth;
+    const testDatabase = getTestPool();
+    pool = testDatabase.pool;
+    db = testDatabase.db;
+
+    staffActor = await seedStaffUser(db, { name: 'Documents Staff' });
+    prepScholar = await seedScholarUser(db, {
+      name: 'Prep Candidate',
+      programStage: 'prep_year',
+    });
+    enrolledScholar = await seedScholarUser(db, {
+      name: 'Enrolled Scholar',
+      programStage: 'scholar',
+    });
+
+    const [passport] = await db
+      .select()
+      .from(requiredDocumentTypes)
+      .where(eq(requiredDocumentTypes.slug, 'passport'))
+      .limit(1);
+    if (!passport) {
+      throw new Error('Expected seeded passport document type');
+    }
+    passportTypeId = passport.id;
+  }, 30000);
+
+  afterAll(async () => {
+    if (createdFileId) {
+      await db.delete(requiredDocumentFiles).where(eq(requiredDocumentFiles.id, createdFileId));
+    }
+    await cleanupSeeded(db, {
+      userIds: [staffActor.userId, prepScholar.userId, enrolledScholar.userId],
+      scholarIds: [prepScholar.scholarId, enrolledScholar.scholarId],
+    });
+    await pool.end();
+    await app.close();
+  }, 15000);
+
+  it('lets a prep candidate upload and lets staff see missing vs submitted plus download', async () => {
+    auth.setUser({
+      id: enrolledScholar.userId,
+      email: enrolledScholar.email,
+      userType: 'scholar',
+    });
+    await request(app.getHttpServer())
+      .post('/api/documents/upload-url')
+      .send({
+        typeId: passportTypeId,
+        fileName: 'passport.pdf',
+        fileType: 'application/pdf',
+        fileSize: 2048,
+      })
+      .expect(403);
+
+    auth.setUser({
+      id: prepScholar.userId,
+      email: prepScholar.email,
+      userType: 'scholar',
+    });
+
+    const uploadResponse = await request(app.getHttpServer())
+      .post('/api/documents/upload-url')
+      .send({
+        typeId: passportTypeId,
+        fileName: 'passport.pdf',
+        fileType: 'application/pdf',
+        fileSize: 2048,
+      })
+      .expect(201);
+
+    expect(uploadResponse.body.fileKey).toMatch(
+      new RegExp(`^documents/pending/${prepScholar.scholarId}/`)
+    );
+
+    const confirmResponse = await request(app.getHttpServer())
+      .post('/api/documents')
+      .send({
+        typeId: passportTypeId,
+        pendingFileKey: uploadResponse.body.fileKey,
+        fileName: 'passport.pdf',
+        fileMimeType: 'application/pdf',
+        fileSizeBytes: 2048,
+      })
+      .expect(201);
+
+    createdFileId = confirmResponse.body.id;
+    expect(objectStorage.copyObject).toHaveBeenCalled();
+
+    const checklist = await request(app.getHttpServer())
+      .get('/api/documents/my-checklist')
+      .expect(200);
+    const passportItem = checklist.body.items.find(
+      (item: { type: { slug: string } }) => item.type.slug === 'passport'
+    );
+    expect(passportItem.status).toBe('submitted');
+
+    auth.setUser({
+      id: enrolledScholar.userId,
+      email: enrolledScholar.email,
+      userType: 'scholar',
+    });
+    await request(app.getHttpServer()).get(`/api/documents/${createdFileId}/download`).expect(404);
+
+    auth.setUser({
+      id: staffActor.userId,
+      email: staffActor.email,
+      userType: 'staff',
+    });
+
+    const cohort = await request(app.getHttpServer()).get('/api/documents/cohort').expect(200);
+    const prepRow = cohort.body.scholars.find(
+      (row: { scholarId: string }) => row.scholarId === prepScholar.scholarId
+    );
+    expect(prepRow).toBeDefined();
+    const submittedCell = prepRow.items.find(
+      (item: { typeId: string }) => item.typeId === passportTypeId
+    );
+    expect(submittedCell.status).toBe('submitted');
+
+    const missingOnly = await request(app.getHttpServer())
+      .get(`/api/documents/cohort?missingTypeId=${passportTypeId}`)
+      .expect(200);
+    expect(
+      missingOnly.body.scholars.some(
+        (row: { scholarId: string }) => row.scholarId === prepScholar.scholarId
+      )
+    ).toBe(false);
+
+    const download = await request(app.getHttpServer())
+      .get(`/api/documents/${createdFileId}/download`)
+      .expect(200);
+    expect(download.body.downloadUrl).toBe('https://s3.example/signed-get');
+  });
+});

--- a/apps/scholar/app/(scholar)/documents/page.test.tsx
+++ b/apps/scholar/app/(scholar)/documents/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockReplace = jest.fn();
+const mockGetMyProfile = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: jest.fn(),
+    prefetch: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../lib/api/profile', () => ({
+  getMyProfile: (...args: unknown[]) => mockGetMyProfile(...args),
+}));
+
+jest.mock('../../../components/my-documents', () => ({
+  MyDocuments: () => <div>Documents checklist</div>,
+}));
+
+import { ScholarSessionProvider } from '../../../lib/scholar-session';
+import DocumentsPage from './page';
+
+function renderPage() {
+  return render(
+    <ScholarSessionProvider>
+      <DocumentsPage />
+    </ScholarSessionProvider>
+  );
+}
+
+describe('DocumentsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects confirmed scholars to the dashboard', async () => {
+    mockGetMyProfile.mockResolvedValue({ programStage: 'scholar' });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/dashboard');
+    });
+    expect(screen.queryByText('Documents checklist')).not.toBeInTheDocument();
+  });
+
+  it('renders documents for prep-year candidates', async () => {
+    mockGetMyProfile.mockResolvedValue({ programStage: 'prep_year' });
+
+    renderPage();
+
+    expect(await screen.findByText('Documents checklist')).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it('redirects to the dashboard if profile loading fails', async () => {
+    mockGetMyProfile.mockRejectedValue(new Error('offline'));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/dashboard');
+    });
+    expect(screen.queryByText('Documents checklist')).not.toBeInTheDocument();
+  });
+});

--- a/apps/scholar/app/(scholar)/documents/page.tsx
+++ b/apps/scholar/app/(scholar)/documents/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { MyDocuments } from '../../../components/my-documents';
+import { useScholarSession } from '../../../lib/scholar-session';
+
+export default function DocumentsPage() {
+  const router = useRouter();
+  const { programStage, profileStatus } = useScholarSession();
+  const [allowed, setAllowed] = useState(false);
+
+  useEffect(() => {
+    if (profileStatus === 'loading') return;
+    if (profileStatus === 'error' || programStage !== 'prep_year') {
+      router.replace('/dashboard');
+      return;
+    }
+    setAllowed(true);
+  }, [profileStatus, programStage, router]);
+
+  if (!allowed) {
+    return <div className="p-6 text-muted-foreground">Redirecting...</div>;
+  }
+
+  return (
+    <div className="p-6">
+      <MyDocuments />
+    </div>
+  );
+}

--- a/apps/scholar/components/__tests__/scholar-layout.test.tsx
+++ b/apps/scholar/components/__tests__/scholar-layout.test.tsx
@@ -111,7 +111,7 @@ describe('ScholarLayout', () => {
     expect(screen.queryByRole('heading', { name: 'Ashinaga Prep Year' })).not.toBeInTheDocument();
   });
 
-  it('hides annual review for prep-year users and does not add My Documents', async () => {
+  it('shows My Documents for prep-year users and hides annual review', async () => {
     mockGetMyProfile.mockResolvedValue({ programStage: 'prep_year' });
 
     await renderLayout(<div>content</div>);
@@ -119,7 +119,10 @@ describe('ScholarLayout', () => {
     expect(screen.getByRole('heading', { name: 'Ashinaga Prep Year' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'My LDF' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'My Annual Review' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'My Documents' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'My Documents' })).toHaveAttribute(
+      'href',
+      '/documents'
+    );
   });
 
   it('does not show annual review when profile loading fails', async () => {
@@ -129,5 +132,6 @@ describe('ScholarLayout', () => {
 
     expect(screen.getByRole('link', { name: 'My LDF' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'My Annual Review' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'My Documents' })).not.toBeInTheDocument();
   });
 });

--- a/apps/scholar/components/my-documents.tsx
+++ b/apps/scholar/components/my-documents.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { Download, FileText, Loader2, Upload } from 'lucide-react';
+import { useRef, useState } from 'react';
+import {
+  confirmDocumentUpload,
+  createDocumentUploadUrl,
+  getRequiredDocumentDownloadUrl,
+  type RequiredDocumentChecklistItem,
+} from '../lib/api-client';
+import { queryKeys, useMyDocumentChecklist } from '../lib/hooks/use-queries';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { useToast } from './ui/use-toast';
+
+const ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+] as const;
+
+const MIME_BY_EXTENSION: Record<string, (typeof ALLOWED_MIME_TYPES)[number]> = {
+  '.pdf': 'application/pdf',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+};
+
+function resolveMimeType(file: File): (typeof ALLOWED_MIME_TYPES)[number] | null {
+  if (ALLOWED_MIME_TYPES.includes(file.type as (typeof ALLOWED_MIME_TYPES)[number])) {
+    return file.type === 'image/jpg'
+      ? 'image/jpeg'
+      : (file.type as (typeof ALLOWED_MIME_TYPES)[number]);
+  }
+  const extension = file.name.includes('.')
+    ? `.${file.name.split('.').pop()?.toLowerCase() ?? ''}`
+    : '';
+  return MIME_BY_EXTENSION[extension] ?? null;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : 'Something went wrong. Please try again.';
+}
+
+export function MyDocuments() {
+  const { data, isLoading, error } = useMyDocumentChecklist();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [busyTypeId, setBusyTypeId] = useState<string | null>(null);
+
+  const uploadForType = async (typeId: string, file: File) => {
+    const fileType = resolveMimeType(file);
+    if (!fileType) {
+      throw new Error('Please choose a PDF, JPEG, PNG, or WebP file.');
+    }
+    if (file.size < 1 || file.size > 10 * 1024 * 1024) {
+      throw new Error('Please choose a file smaller than 10MB.');
+    }
+
+    const { uploadUrl, fields, fileKey } = await createDocumentUploadUrl({
+      typeId,
+      fileName: file.name,
+      fileType,
+      fileSize: file.size,
+    });
+
+    const formData = new FormData();
+    for (const [key, value] of Object.entries(fields)) {
+      formData.append(key, value);
+    }
+    formData.append('file', file);
+
+    const uploadResponse = await fetch(uploadUrl, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!uploadResponse.ok) {
+      throw new Error('Could not upload the document. Please try again.');
+    }
+
+    await confirmDocumentUpload({
+      typeId,
+      pendingFileKey: fileKey,
+      fileName: file.name,
+      fileMimeType: fileType,
+      fileSizeBytes: file.size,
+    });
+    await queryClient.invalidateQueries({ queryKey: queryKeys.myDocuments });
+  };
+
+  const handleDownload = async (fileId: string) => {
+    const { downloadUrl } = await getRequiredDocumentDownloadUrl(fileId, 'attachment');
+    window.location.href = downloadUrl;
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+        Loading your documents...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-destructive">Could not load required documents. Please retry.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">My Documents</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Upload the required Prep Year documents. You can replace a file if you need to update it.
+        </p>
+      </div>
+      <div className="space-y-3">
+        {(data?.items ?? []).map((item) => (
+          <DocumentTypeCard
+            key={item.type.id}
+            item={item}
+            busy={busyTypeId === item.type.id}
+            onBusy={(busy) => setBusyTypeId(busy ? item.type.id : null)}
+            onUpload={uploadForType}
+            onDownload={handleDownload}
+            onError={(message) =>
+              toast({
+                title: 'Could not update document',
+                description: message,
+                variant: 'destructive',
+              })
+            }
+            onSuccess={(message) => toast({ title: message })}
+            errorMessage={getErrorMessage}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DocumentTypeCard({
+  item,
+  busy,
+  onBusy,
+  onUpload,
+  onDownload,
+  onError,
+  onSuccess,
+  errorMessage,
+}: {
+  item: RequiredDocumentChecklistItem;
+  busy: boolean;
+  onBusy: (busy: boolean) => void;
+  onUpload: (typeId: string, file: File) => Promise<void>;
+  onDownload: (fileId: string) => Promise<void>;
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+  errorMessage: (error: unknown) => string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const submitted = item.status === 'submitted' && item.file;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border bg-card p-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 items-start gap-3">
+        <FileText className="mt-0.5 h-8 w-8 shrink-0 text-muted-foreground" />
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="font-medium">{item.type.label}</h3>
+            <Badge variant={submitted ? 'default' : 'secondary'}>
+              {submitted ? 'Submitted' : 'Missing'}
+            </Badge>
+          </div>
+          {item.type.description ? (
+            <p className="mt-1 text-sm text-muted-foreground">{item.type.description}</p>
+          ) : null}
+          {submitted ? (
+            <p className="mt-1 truncate text-sm text-muted-foreground">
+              {item.file?.fileName} · {new Date(item.file?.uploadedAt ?? '').toLocaleDateString()}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          ref={inputRef}
+          type="file"
+          className="hidden"
+          accept=".pdf,.jpg,.jpeg,.png,.webp,application/pdf,image/jpeg,image/png,image/webp"
+          onChange={async (event) => {
+            const file = event.target.files?.[0];
+            event.target.value = '';
+            if (!file) return;
+            onBusy(true);
+            try {
+              await onUpload(item.type.id, file);
+              onSuccess(submitted ? 'Document replaced' : 'Document uploaded');
+            } catch (error) {
+              onError(errorMessage(error));
+            } finally {
+              onBusy(false);
+            }
+          }}
+        />
+        {submitted ? (
+          <>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={async () => {
+                if (!item.file) return;
+                onBusy(true);
+                try {
+                  await onDownload(item.file.id);
+                } catch (error) {
+                  onError(errorMessage(error));
+                } finally {
+                  onBusy(false);
+                }
+              }}
+            >
+              <Download className="mr-1 h-4 w-4" />
+              Download
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy}
+              onClick={() => inputRef.current?.click()}
+            >
+              {busy ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+              ) : (
+                <Upload className="mr-1 h-4 w-4" />
+              )}
+              Replace
+            </Button>
+          </>
+        ) : (
+          <Button size="sm" disabled={busy} onClick={() => inputRef.current?.click()}>
+            {busy ? (
+              <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+            ) : (
+              <Upload className="mr-1 h-4 w-4" />
+            )}
+            Upload
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/scholar/components/scholar-layout.tsx
+++ b/apps/scholar/components/scholar-layout.tsx
@@ -6,6 +6,7 @@ import {
   ChevronLeft,
   ClipboardCheck,
   FileText,
+  FolderOpen,
   Home,
   Library,
   LogOut,
@@ -42,6 +43,7 @@ type ProgramStage = 'prep_year' | 'scholar';
 const NAV_ITEMS = [
   { id: 'dashboard', href: '/dashboard', label: 'Overview', icon: Home },
   { id: 'profile', href: '/profile', label: 'My Profile', icon: User },
+  { id: 'documents', href: '/documents', label: 'My Documents', icon: FolderOpen },
   { id: 'goals', href: '/goals', label: 'My LDF', icon: Target },
   { id: 'annual-review', href: '/annual-review', label: 'My Annual Review', icon: ClipboardCheck },
   { id: 'tasks', href: '/tasks', label: 'My Tasks', icon: CheckSquare },
@@ -55,11 +57,11 @@ type NavItem = (typeof NAV_ITEMS)[number];
 const HOME_HREF = '/dashboard';
 
 function getVisibleNavItems(programStage: ProgramStage | null): readonly NavItem[] {
-  // Fail closed: hide Annual Review until we know the user is an enrolled scholar.
-  if (programStage === 'scholar') {
-    return NAV_ITEMS;
-  }
-  return NAV_ITEMS.filter((item) => item.id !== 'annual-review');
+  return NAV_ITEMS.filter((item) => {
+    if (item.id === 'annual-review') return programStage === 'scholar';
+    if (item.id === 'documents') return programStage === 'prep_year';
+    return true;
+  });
 }
 
 function getScholarSection(pathname: string, navItems: readonly NavItem[]) {

--- a/apps/scholar/lib/api-client.ts
+++ b/apps/scholar/lib/api-client.ts
@@ -207,5 +207,82 @@ export async function getResourceDownloadUrl(
   return fetchAPI<{ downloadUrl: string }>(`/api/resources/${resourceId}/download${query}`);
 }
 
+export interface RequiredDocumentType {
+  id: string;
+  slug: string;
+  label: string;
+  description: string | null;
+  isActive: boolean;
+  sortOrder: number;
+}
+
+export interface RequiredDocumentFile {
+  id: string;
+  typeId: string;
+  typeSlug?: string;
+  typeLabel?: string;
+  fileName: string;
+  fileMimeType: string;
+  fileSizeBytes: number;
+  uploadedAt: string;
+}
+
+export interface RequiredDocumentChecklistItem {
+  type: RequiredDocumentType;
+  status: 'submitted' | 'missing';
+  file: RequiredDocumentFile | null;
+}
+
+export interface RequiredDocumentChecklist {
+  scholarId: string;
+  items: RequiredDocumentChecklistItem[];
+}
+
+export async function getMyDocumentChecklist(): Promise<RequiredDocumentChecklist> {
+  return fetchAPI<RequiredDocumentChecklist>('/api/documents/my-checklist');
+}
+
+export async function createDocumentUploadUrl(data: {
+  typeId: string;
+  fileName: string;
+  fileType: string;
+  fileSize: number;
+}): Promise<{ uploadUrl: string; fields: Record<string, string>; fileKey: string }> {
+  return fetchAPI<{ uploadUrl: string; fields: Record<string, string>; fileKey: string }>(
+    '/api/documents/upload-url',
+    {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }
+  );
+}
+
+export async function confirmDocumentUpload(data: {
+  typeId: string;
+  pendingFileKey: string;
+  fileName: string;
+  fileMimeType: string;
+  fileSizeBytes: number;
+}): Promise<RequiredDocumentFile> {
+  return fetchAPI<RequiredDocumentFile>('/api/documents', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function deleteMyDocument(fileId: string): Promise<{ success: boolean }> {
+  return fetchAPI<{ success: boolean }>(`/api/documents/${fileId}`, {
+    method: 'DELETE',
+  });
+}
+
+export async function getRequiredDocumentDownloadUrl(
+  fileId: string,
+  disposition: 'attachment' | 'inline' = 'attachment'
+): Promise<{ downloadUrl: string }> {
+  const query = disposition === 'inline' ? '?disposition=inline' : '';
+  return fetchAPI<{ downloadUrl: string }>(`/api/documents/${fileId}/download${query}`);
+}
+
 // Export the fetchAPI function and any other API functions as needed
 export { fetchAPI };

--- a/apps/scholar/lib/hooks/use-queries.ts
+++ b/apps/scholar/lib/hooks/use-queries.ts
@@ -3,6 +3,7 @@ import {
   createRequest,
   type GetMyAnnouncementsParams,
   getMyAnnouncements,
+  getMyDocumentChecklist,
   getMyRequests,
   getMyResources,
   getStaffList,
@@ -13,6 +14,7 @@ export const queryKeys = {
   myAnnouncements: (params?: GetMyAnnouncementsParams) => ['my-announcements', params] as const,
   myResources: ['my-resources'] as const,
   myRequests: ['my-requests'] as const,
+  myDocuments: ['my-documents'] as const,
   staffList: ['staff-list'] as const,
 };
 
@@ -39,6 +41,14 @@ export function useMyResources(enabled = true) {
   return useQuery({
     queryKey: queryKeys.myResources,
     queryFn: getMyResources,
+    enabled,
+  });
+}
+
+export function useMyDocumentChecklist(enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.myDocuments,
+    queryFn: getMyDocumentChecklist,
     enabled,
   });
 }

--- a/apps/staff/app/page.tsx
+++ b/apps/staff/app/page.tsx
@@ -17,6 +17,7 @@ import { AnnualReviewsReport } from '../components/annual-reviews-report';
 import { InvitationsManagement } from '../components/invitations-management';
 import { LoginPage } from '../components/login-page';
 import { MyProfile } from '../components/my-profile';
+import { PrepDocumentsTracker } from '../components/prep-documents-tracker';
 import { RequestManagement } from '../components/request-management';
 import { ResourcesManagement } from '../components/resources-management';
 import { ScholarManagementTable } from '../components/scholar-management-table';
@@ -409,6 +410,7 @@ function StaffDashboardContent() {
               >
                 {activeTab === 'overview' && 'Overview'}
                 {activeTab === 'scholars' && 'Scholars'}
+                {activeTab === 'prep-documents' && 'Prep documents'}
                 {activeTab === 'annual-reviews' && 'Annual Reviews'}
                 {activeTab === 'requests' && 'Requests'}
                 {activeTab === 'announcements' && 'Announcements'}
@@ -418,6 +420,8 @@ function StaffDashboardContent() {
               <p className="text-sm text-muted-foreground mt-0.5">
                 {activeTab === 'overview' && 'Your dashboard at a glance.'}
                 {activeTab === 'scholars' && 'View and manage your assigned scholars.'}
+                {activeTab === 'prep-documents' &&
+                  'See submitted and missing Prep Year documents without opening each profile.'}
                 {activeTab === 'annual-reviews' &&
                   'Track annual review submissions by scholar and academic year.'}
                 {activeTab === 'requests' && 'Review and respond to scholar submissions.'}
@@ -575,6 +579,22 @@ function StaffDashboardContent() {
                     </CardContent>
                   </Card>
                 )}
+              </div>
+            )}
+
+            {activeTab === 'prep-documents' && (
+              <div className="space-y-6">
+                <Card>
+                  <CardContent className="p-4 sm:p-5">
+                    <PrepDocumentsTracker
+                      onViewScholar={(scholarId) => {
+                        router.push(
+                          `?tab=scholars&view=scholar-profile&scholarId=${scholarId}&scholarTab=documents`
+                        );
+                      }}
+                    />
+                  </CardContent>
+                </Card>
               </div>
             )}
 

--- a/apps/staff/components/__tests__/prep-documents-tracker.test.tsx
+++ b/apps/staff/components/__tests__/prep-documents-tracker.test.tsx
@@ -90,6 +90,10 @@ describe('PrepDocumentsTracker', () => {
     expect(screen.getByText('Ben Candidate')).toBeInTheDocument();
     expect(screen.getAllByText('Missing').length).toBeGreaterThan(0);
     expect(screen.getByText('Submitted')).toBeInTheDocument();
-    expect(screen.getByText('passport.pdf')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `passport.pdf · ${new Date('2026-08-01T00:00:00.000Z').toLocaleDateString()}`
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/apps/staff/components/__tests__/prep-documents-tracker.test.tsx
+++ b/apps/staff/components/__tests__/prep-documents-tracker.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { PrepDocumentsTracker } from '../prep-documents-tracker';
+
+const mockGetCohort = jest.fn();
+const mockGetTypes = jest.fn();
+
+jest.mock(
+  'lucide-react',
+  () =>
+    new Proxy(
+      {},
+      {
+        get: (_target, prop) => (prop === '__esModule' ? true : () => null),
+      }
+    )
+);
+
+jest.mock('../../lib/api-client', () => ({
+  getRequiredDocumentCohort: (...args: unknown[]) => mockGetCohort(...args),
+  getRequiredDocumentTypes: (...args: unknown[]) => mockGetTypes(...args),
+  createRequiredDocumentType: jest.fn(),
+  updateRequiredDocumentType: jest.fn(),
+  getRequiredDocumentDownloadUrl: jest.fn(),
+}));
+
+function renderTracker() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PrepDocumentsTracker onViewScholar={jest.fn()} />
+    </QueryClientProvider>
+  );
+}
+
+describe('PrepDocumentsTracker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetTypes.mockResolvedValue([
+      {
+        id: 'type-1',
+        slug: 'passport',
+        label: 'Passport copy',
+        description: null,
+        isActive: true,
+        sortOrder: 1,
+      },
+    ]);
+  });
+
+  it('shows missing and submitted cells for the prep cohort', async () => {
+    mockGetCohort.mockResolvedValue({
+      types: [
+        {
+          id: 'type-1',
+          slug: 'passport',
+          label: 'Passport copy',
+          description: null,
+          isActive: true,
+          sortOrder: 1,
+        },
+      ],
+      scholars: [
+        {
+          scholarId: 's1',
+          name: 'Ada Candidate',
+          email: 'ada@example.com',
+          items: [{ typeId: 'type-1', status: 'missing', file: null }],
+        },
+        {
+          scholarId: 's2',
+          name: 'Ben Candidate',
+          email: 'ben@example.com',
+          items: [
+            {
+              typeId: 'type-1',
+              status: 'submitted',
+              file: { id: 'f1', fileName: 'passport.pdf', uploadedAt: '2026-08-01T00:00:00.000Z' },
+            },
+          ],
+        },
+      ],
+    });
+
+    renderTracker();
+
+    expect(await screen.findByText('Ada Candidate')).toBeInTheDocument();
+    expect(screen.getByText('Ben Candidate')).toBeInTheDocument();
+    expect(screen.getAllByText('Missing').length).toBeGreaterThan(0);
+    expect(screen.getByText('Submitted')).toBeInTheDocument();
+    expect(screen.getByText('passport.pdf')).toBeInTheDocument();
+  });
+});

--- a/apps/staff/components/__tests__/staff-layout.test.tsx
+++ b/apps/staff/components/__tests__/staff-layout.test.tsx
@@ -47,6 +47,10 @@ describe('StaffLayout', () => {
 
     expect(screen.getByRole('heading', { name: 'Ashinaga Staff' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute('href', '/');
+    expect(screen.getByRole('link', { name: 'Prep documents' })).toHaveAttribute(
+      'href',
+      '/?tab=prep-documents'
+    );
     expect(screen.getByRole('link', { name: 'Annual Reviews' })).toHaveAttribute(
       'href',
       '/?tab=annual-reviews'

--- a/apps/staff/components/prep-documents-tracker.tsx
+++ b/apps/staff/components/prep-documents-tracker.tsx
@@ -41,7 +41,7 @@ export function PrepDocumentsTracker({
   const handleDownload = async (fileId: string) => {
     try {
       const { downloadUrl } = await getRequiredDocumentDownloadUrl(fileId);
-      window.location.href = downloadUrl;
+      window.open(downloadUrl, '_blank');
     } catch (downloadError) {
       toast({
         title: 'Could not download file',
@@ -164,6 +164,9 @@ export function PrepDocumentsTracker({
                             <Badge>Submitted</Badge>
                             <span className="max-w-[140px] truncate text-xs text-muted-foreground">
                               {cell.file?.fileName}
+                              {cell.file?.uploadedAt
+                                ? ` · ${new Date(cell.file.uploadedAt).toLocaleDateString()}`
+                                : ''}
                             </span>
                             <Button
                               size="sm"

--- a/apps/staff/components/prep-documents-tracker.tsx
+++ b/apps/staff/components/prep-documents-tracker.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { Download, Loader2, Plus } from 'lucide-react';
+import { useState } from 'react';
+import {
+  createRequiredDocumentType,
+  getRequiredDocumentDownloadUrl,
+  updateRequiredDocumentType,
+} from '../lib/api-client';
+import { useRequiredDocumentCohort, useRequiredDocumentTypes } from '../lib/hooks/use-queries';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './ui/table';
+import { useToast } from './ui/use-toast';
+
+export function PrepDocumentsTracker({
+  onViewScholar,
+}: {
+  onViewScholar: (scholarId: string) => void;
+}) {
+  const [missingTypeId, setMissingTypeId] = useState<string>('all');
+  const { data, isLoading, error } = useRequiredDocumentCohort(
+    missingTypeId === 'all' ? undefined : missingTypeId
+  );
+  const { data: allTypes = [] } = useRequiredDocumentTypes();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [newLabel, setNewLabel] = useState('');
+  const [savingType, setSavingType] = useState(false);
+
+  const types = data?.types ?? [];
+  const scholars = data?.scholars ?? [];
+
+  const refresh = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['required-documents'] });
+  };
+
+  const handleDownload = async (fileId: string) => {
+    try {
+      const { downloadUrl } = await getRequiredDocumentDownloadUrl(fileId);
+      window.location.href = downloadUrl;
+    } catch (downloadError) {
+      toast({
+        title: 'Could not download file',
+        description: downloadError instanceof Error ? downloadError.message : 'Please try again.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const handleAddType = async () => {
+    const label = newLabel.trim();
+    if (!label) return;
+    setSavingType(true);
+    try {
+      await createRequiredDocumentType({ label });
+      setNewLabel('');
+      await refresh();
+      toast({ title: 'Document type added' });
+    } catch (addError) {
+      toast({
+        title: 'Could not add type',
+        description: addError instanceof Error ? addError.message : 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setSavingType(false);
+    }
+  };
+
+  const handleToggleType = async (typeId: string, isActive: boolean) => {
+    try {
+      await updateRequiredDocumentType(typeId, { isActive: !isActive });
+      await refresh();
+    } catch (toggleError) {
+      toast({
+        title: 'Could not update type',
+        description: toggleError instanceof Error ? toggleError.message : 'Please try again.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+        Loading Prep Year documents...
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-destructive">Could not load the document tracker.</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold">Cohort status</h3>
+          <p className="text-sm text-muted-foreground">
+            Submitted and missing required documents for Prep Year candidates.
+          </p>
+        </div>
+        <Select value={missingTypeId} onValueChange={setMissingTypeId}>
+          <SelectTrigger className="w-full sm:w-[240px]">
+            <SelectValue placeholder="Filter missing" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All candidates</SelectItem>
+            {types.map((type) => (
+              <SelectItem key={type.id} value={type.id}>
+                Missing {type.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Candidate</TableHead>
+              {types.map((type) => (
+                <TableHead key={type.id}>{type.label}</TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {scholars.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={Math.max(types.length + 1, 1)}
+                  className="text-center text-muted-foreground"
+                >
+                  No Prep Year candidates match this filter.
+                </TableCell>
+              </TableRow>
+            ) : (
+              scholars.map((scholar) => (
+                <TableRow key={scholar.scholarId}>
+                  <TableCell>
+                    <button
+                      type="button"
+                      className="text-left font-medium hover:underline"
+                      onClick={() => onViewScholar(scholar.scholarId)}
+                    >
+                      {scholar.name}
+                    </button>
+                    <p className="text-xs text-muted-foreground">{scholar.email}</p>
+                  </TableCell>
+                  {types.map((type) => {
+                    const cell = scholar.items.find((item) => item.typeId === type.id);
+                    const submitted = cell?.status === 'submitted' && cell.file;
+                    return (
+                      <TableCell key={type.id}>
+                        {submitted ? (
+                          <div className="flex items-center gap-2">
+                            <Badge>Submitted</Badge>
+                            <span className="max-w-[140px] truncate text-xs text-muted-foreground">
+                              {cell.file?.fileName}
+                            </span>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => cell.file && handleDownload(cell.file.id)}
+                            >
+                              <Download className="h-3.5 w-3.5" />
+                              <span className="sr-only">Download</span>
+                            </Button>
+                          </div>
+                        ) : (
+                          <Badge variant="secondary">Missing</Badge>
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="space-y-3 rounded-lg border p-4">
+        <h3 className="text-sm font-semibold">Manage required types</h3>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Input
+            value={newLabel}
+            onChange={(event) => setNewLabel(event.target.value)}
+            placeholder="Add a document type"
+          />
+          <Button type="button" onClick={handleAddType} disabled={savingType || !newLabel.trim()}>
+            <Plus className="mr-1 h-4 w-4" />
+            Add type
+          </Button>
+        </div>
+        <ul className="space-y-2">
+          {allTypes.map((type) => (
+            <li key={type.id} className="flex items-center justify-between gap-3 text-sm">
+              <span>
+                {type.label}
+                {!type.isActive ? (
+                  <span className="ml-2 text-muted-foreground">(inactive)</span>
+                ) : null}
+              </span>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => handleToggleType(type.id, type.isActive)}
+              >
+                {type.isActive ? 'Deactivate' : 'Reactivate'}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/staff/components/scholar-profile.tsx
+++ b/apps/staff/components/scholar-profile.tsx
@@ -1285,7 +1285,7 @@ export function ScholarProfilePage({
                               const { downloadUrl } = await getRequiredDocumentDownloadUrl(
                                 item.file!.id
                               );
-                              window.location.href = downloadUrl;
+                              window.open(downloadUrl, '_blank');
                             }}
                           >
                             <Download className="mr-1 h-4 w-4" />

--- a/apps/staff/components/scholar-profile.tsx
+++ b/apps/staff/components/scholar-profile.tsx
@@ -24,6 +24,7 @@ import {
   downloadScholarAnnualReviewsCSV,
   getFileDownloadUrl,
   getFilterOptions,
+  getRequiredDocumentDownloadUrl,
   type ScholarFilterOptions,
   type UpdateScholarProfileData,
 } from '../lib/api-client';
@@ -43,6 +44,7 @@ import {
   useDeleteTask,
   useScholarAnnualUpdates,
   useScholarProfile,
+  useScholarRequiredDocuments,
   useUpdateScholarProfile,
 } from '../lib/hooks/use-queries';
 import { CommentThread } from './comment-thread';
@@ -89,6 +91,8 @@ export function ScholarProfilePage({
     scholarId,
     activeTab === 'annual-reviews'
   );
+  const { data: requiredDocuments, isLoading: requiredDocumentsLoading } =
+    useScholarRequiredDocuments(scholarId, scholar?.programStage === 'prep_year');
   const updateProfile = useUpdateScholarProfile(scholarId);
   const [editOpen, setEditOpen] = useState(false);
   const [enrollOpen, setEnrollOpen] = useState(false);
@@ -1248,38 +1252,88 @@ export function ScholarProfilePage({
           <div className="flex items-center justify-between">
             <h3 className="text-lg font-semibold">Documents</h3>
           </div>
-          <div className="space-y-4">
-            {scholar.documents.length === 0 ? (
-              <Card>
-                <CardContent className="pt-4">
-                  <p className="text-muted-foreground text-center py-4">
-                    No documents uploaded yet
-                  </p>
-                </CardContent>
-              </Card>
-            ) : (
-              scholar.documents.map((doc) => (
-                <Card key={doc.id}>
-                  <CardContent className="pt-4">
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-3">
-                        <FileText className="h-8 w-8 text-muted-foreground" />
-                        <div>
-                          <h4 className="font-medium">{doc.name}</h4>
-                          <p className="text-sm text-muted-foreground">
-                            Uploaded {new Date(doc.uploadDate).toLocaleDateString()} • {doc.type}
-                          </p>
-                        </div>
-                      </div>
-                      <Button size="sm" variant="outline">
-                        Download
-                      </Button>
-                    </div>
+          {scholar.programStage === 'prep_year' ? (
+            <div className="space-y-3">
+              {requiredDocumentsLoading ? (
+                <Card>
+                  <CardContent className="flex items-center justify-center py-8 text-muted-foreground">
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Loading required documents...
                   </CardContent>
                 </Card>
-              ))
-            )}
-          </div>
+              ) : (
+                (requiredDocuments?.items ?? []).map((item) => (
+                  <Card key={item.type.id}>
+                    <CardContent className="pt-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="flex min-w-0 items-center gap-3">
+                          <FileText className="h-8 w-8 shrink-0 text-muted-foreground" />
+                          <div className="min-w-0">
+                            <h4 className="font-medium">{item.type.label}</h4>
+                            <p className="text-sm text-muted-foreground">
+                              {item.status === 'submitted' && item.file
+                                ? `${item.file.fileName} · ${new Date(item.file.uploadedAt).toLocaleDateString()}`
+                                : 'Missing'}
+                            </p>
+                          </div>
+                        </div>
+                        {item.file ? (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={async () => {
+                              const { downloadUrl } = await getRequiredDocumentDownloadUrl(
+                                item.file!.id
+                              );
+                              window.location.href = downloadUrl;
+                            }}
+                          >
+                            <Download className="mr-1 h-4 w-4" />
+                            Download
+                          </Button>
+                        ) : (
+                          <Badge variant="secondary">Missing</Badge>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))
+              )}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {scholar.documents.length === 0 ? (
+                <Card>
+                  <CardContent className="pt-4">
+                    <p className="text-muted-foreground text-center py-4">
+                      No documents uploaded yet
+                    </p>
+                  </CardContent>
+                </Card>
+              ) : (
+                scholar.documents.map((doc) => (
+                  <Card key={doc.id}>
+                    <CardContent className="pt-4">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <FileText className="h-8 w-8 text-muted-foreground" />
+                          <div>
+                            <h4 className="font-medium">{doc.name}</h4>
+                            <p className="text-sm text-muted-foreground">
+                              Uploaded {new Date(doc.uploadDate).toLocaleDateString()} • {doc.type}
+                            </p>
+                          </div>
+                        </div>
+                        <Button size="sm" variant="outline">
+                          Download
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))
+              )}
+            </div>
+          )}
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/staff/components/staff-layout.tsx
+++ b/apps/staff/components/staff-layout.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeft,
   ClipboardCheck,
   FileText,
+  FolderOpen,
   Home,
   Library,
   LogOut,
@@ -33,6 +34,12 @@ import {
 export const STAFF_NAV_ITEMS = [
   { href: '/', value: 'overview', label: 'Overview', icon: Home },
   { href: '/?tab=scholars', value: 'scholars', label: 'Scholars', icon: Users },
+  {
+    href: '/?tab=prep-documents',
+    value: 'prep-documents',
+    label: 'Prep documents',
+    icon: FolderOpen,
+  },
   {
     href: '/?tab=annual-reviews',
     value: 'annual-reviews',

--- a/apps/staff/lib/api-client.ts
+++ b/apps/staff/lib/api-client.ts
@@ -1079,6 +1079,102 @@ export async function getResourceDownloadUrl(
   return fetchAPI<{ downloadUrl: string }>(`/api/resources/${resourceId}/download${query}`);
 }
 
+export interface RequiredDocumentType {
+  id: string;
+  slug: string;
+  label: string;
+  description: string | null;
+  isActive: boolean;
+  sortOrder: number;
+}
+
+export interface RequiredDocumentFileSummary {
+  id: string;
+  fileName: string;
+  uploadedAt: string;
+}
+
+export interface RequiredDocumentCohortItem {
+  typeId: string;
+  status: 'submitted' | 'missing';
+  file: RequiredDocumentFileSummary | null;
+}
+
+export interface RequiredDocumentCohortScholar {
+  scholarId: string;
+  name: string;
+  email: string;
+  items: RequiredDocumentCohortItem[];
+}
+
+export interface RequiredDocumentCohort {
+  types: RequiredDocumentType[];
+  scholars: RequiredDocumentCohortScholar[];
+}
+
+export interface RequiredDocumentChecklistItem {
+  type: RequiredDocumentType;
+  status: 'submitted' | 'missing';
+  file: {
+    id: string;
+    typeId: string;
+    fileName: string;
+    fileMimeType: string;
+    fileSizeBytes: number;
+    uploadedAt: string;
+  } | null;
+}
+
+export interface RequiredDocumentChecklist {
+  scholarId: string;
+  items: RequiredDocumentChecklistItem[];
+}
+
+export async function getRequiredDocumentTypes(): Promise<RequiredDocumentType[]> {
+  return fetchAPI<RequiredDocumentType[]>('/api/documents/types');
+}
+
+export async function createRequiredDocumentType(data: {
+  label: string;
+  description?: string;
+}): Promise<RequiredDocumentType> {
+  return fetchAPI<RequiredDocumentType>('/api/documents/types', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateRequiredDocumentType(
+  typeId: string,
+  data: { label?: string; description?: string; isActive?: boolean; sortOrder?: number }
+): Promise<RequiredDocumentType> {
+  return fetchAPI<RequiredDocumentType>(`/api/documents/types/${typeId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  });
+}
+
+export async function getRequiredDocumentCohort(
+  missingTypeId?: string
+): Promise<RequiredDocumentCohort> {
+  const query = missingTypeId ? `?missingTypeId=${encodeURIComponent(missingTypeId)}` : '';
+  return fetchAPI<RequiredDocumentCohort>(`/api/documents/cohort${query}`);
+}
+
+export async function getScholarRequiredDocuments(
+  scholarId: string
+): Promise<RequiredDocumentChecklist> {
+  return fetchAPI<RequiredDocumentChecklist>(`/api/documents/scholar/${scholarId}`);
+}
+
+export async function getRequiredDocumentDownloadUrl(
+  fileId: string,
+  disposition: 'attachment' | 'inline' = 'attachment'
+): Promise<{ downloadUrl: string }> {
+  const query = disposition === 'inline' ? '?disposition=inline' : '';
+  return fetchAPI<{ downloadUrl: string }>(`/api/documents/${fileId}/download${query}`);
+}
+
 // Staff management
 export interface StaffMember {
   id: string;

--- a/apps/staff/lib/hooks/use-queries.ts
+++ b/apps/staff/lib/hooks/use-queries.ts
@@ -9,9 +9,12 @@ import {
   type GetAnnouncementsParams,
   getAnnouncements,
   getAnnualUpdatesByScholar,
+  getRequiredDocumentCohort,
+  getRequiredDocumentTypes,
   getResourceFilterOptions,
   getResources,
   getScholarProfile,
+  getScholarRequiredDocuments,
   getTasksByScholar,
   type ResourceFilterOptions,
   type Task,
@@ -31,6 +34,10 @@ export const queryKeys = {
   announcements: (params?: GetAnnouncementsParams) => ['announcements', params] as const,
   resources: ['resources'] as const,
   resourceFilterOptions: ['resources', 'filter-options'] as const,
+  requiredDocumentCohort: (missingTypeId?: string) =>
+    ['required-documents', 'cohort', missingTypeId ?? 'all'] as const,
+  requiredDocumentTypes: ['required-documents', 'types'] as const,
+  scholarRequiredDocuments: (id: string) => ['scholar', id, 'required-documents'] as const,
 };
 
 // Scholar profile query
@@ -122,6 +129,28 @@ export function useResourceFilterOptions() {
     queryKey: queryKeys.resourceFilterOptions,
     queryFn: getResourceFilterOptions,
     staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useRequiredDocumentCohort(missingTypeId?: string) {
+  return useQuery({
+    queryKey: queryKeys.requiredDocumentCohort(missingTypeId),
+    queryFn: () => getRequiredDocumentCohort(missingTypeId),
+  });
+}
+
+export function useRequiredDocumentTypes() {
+  return useQuery({
+    queryKey: queryKeys.requiredDocumentTypes,
+    queryFn: getRequiredDocumentTypes,
+  });
+}
+
+export function useScholarRequiredDocuments(scholarId: string, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.scholarRequiredDocuments(scholarId),
+    queryFn: () => getScholarRequiredDocuments(scholarId),
+    enabled: !!scholarId && enabled,
   });
 }
 

--- a/infra/modules/s3_bucket/main.tf
+++ b/infra/modules/s3_bucket/main.tf
@@ -113,6 +113,19 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   }
 
   rule {
+    id     = "expire-pending-document-uploads"
+    status = "Enabled"
+
+    filter {
+      prefix = "documents/pending/"
+    }
+
+    expiration {
+      days = 1
+    }
+  }
+
+  rule {
     id     = "expire-archived-resource-uploads"
     status = "Enabled"
 


### PR DESCRIPTION
## Summary

- Adds a Prep Year required-document tracker (`required_document_types` / `required_document_files`) so candidates can upload passport, transcripts, and IELTS (or later types) without writing into the unused legacy `documents` table.
- Scholars in `prep_year` get **My Documents** (`/documents`) and upload via presigned POST; enrolled scholars keep **My Annual Review** and cannot upload or download another candidate's files.
- Staff get a **Prep documents** cohort matrix (`/?tab=prep-documents`), type add/deactivate, and a working download on the prep profile Documents tab. Deleting a scholar removes their stored files first. Pending S3 keys under `documents/pending/` expire after one day.

## PR Checklist (Skills)

- [x] If this PR adds or changes a skill package (`packages/*` with `SKILL.md`), `scripts.dev` points to `src/dev.ts` (non-blocking in root `pnpm dev`).
- [x] Skill wrapper behavior verified:
  - [x] No args => exits `0` with skip message
  - [x] With args => runs intended skill logic
- [x] `.env.example` exists in the skill package and contains placeholders only (no real secrets).
- [x] `SKILL.md` documents `.env.example` -> `.env.local` setup and required env vars.
- [x] `pnpm check:skills` passes locally.
- [x] `pnpm lint` passes locally.
- [x] Root `pnpm dev` does not fail because of this skill package (any remaining failures are unrelated and noted below).

## Validation Notes

- `pnpm check:skills`: not applicable (no skill package changes).
- `pnpm lint`: Biome check on changed files; only pre-existing `any` warnings in scholar `api-client.ts`.
- `pnpm dev` (root) outcome: not started (dev servers are kept running separately).
- Tests: API unit (`documents.upload`, `scholars.service`), integration (`required-documents`), scholar layout/documents page, and staff layout/prep-documents tracker all passing.
- Any unrelated blockers (ports/services/etc.): local Postgres had `program_stage` already applied; CI on an empty database applies 0000→0019 cleanly.